### PR TITLE
Remove `with: null` from `merge` function

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -60,7 +60,7 @@ module.exports = class CapOperatorAddPlugin extends cds.add.Plugin {
         }
 
         const project = cds.add.readProject()
-        await cds.add.merge(__dirname, '../files/chart/Chart.yaml.hbs').into('chart/Chart.yaml', { with: null, project })
+        await cds.add.merge(__dirname, '../files/chart/Chart.yaml.hbs').into('chart/Chart.yaml', { project })
         await copy(join(__dirname, '../files/chart/values.yaml')).to('chart/values.yaml')
         await copy(join(__dirname, '../files/chart/values.schema.json')).to('chart/values.schema.json')
 


### PR DESCRIPTION
I noticed the `with: null` in the `cds.add.merge` – this isn't necessary, the `with` can just be used as an alias to `project`. As we use `project` here we can just remove the `with`.