### PR TITLE
[MISC] Workload definition type fix in defaults

### DIFF
--- a/files/chart/values.yaml
+++ b/files/chart/values.yaml
@@ -28,9 +28,3 @@ imagePullSecrets: []
 
 workloads:
 
-tenantOperations:
-  provisioning: []
-  upgrade: []
-  deprovisioning: []
-
-contentJobs: []

--- a/files/workloads.yaml.hbs
+++ b/files/workloads.yaml.hbs
@@ -32,7 +32,7 @@ workloads:
         {{#hasHtml5Repo}}
         - {{appName}}-html5-repo-host-bind
         {{/hasHtml5Repo}}
-        deploymentDefinition:
+        jobDefinition:
             type: Content
             image:
 
@@ -48,7 +48,7 @@ workloads:
         - {{appName}}-saas-registry-bind
         - {{appName}}-service-manager-bind
         {{/hasMultitenancy}}
-        deploymentDefinition:
+        jobDefinition:
             env:
             - name: CDS_CONFIG
               value:

--- a/test/files/expectedChart/values.yaml
+++ b/test/files/expectedChart/values.yaml
@@ -151,8 +151,3 @@ workloads:
           value: null
       type: TenantOperation
       image: null
-tenantOperations:
-  provisioning: []
-  upgrade: []
-  deprovisioning: []
-contentJobs: []

--- a/test/files/expectedChart/values.yaml
+++ b/test/files/expectedChart/values.yaml
@@ -134,7 +134,7 @@ workloads:
       - bookshop-uaa-bind
       - bookshop-saas-registry-bind
       - bookshop-html5-repo-host-bind
-    deploymentDefinition:
+    jobDefinition:
       type: Content
       image: null
   tenant-job:
@@ -145,7 +145,7 @@ workloads:
       - bookshop-uaa-bind
       - bookshop-saas-registry-bind
       - bookshop-service-manager-bind
-    deploymentDefinition:
+    jobDefinition:
       env:
         - name: CDS_CONFIG
           value: null

--- a/test/files/expectedChart/valuesWithDestination.yaml
+++ b/test/files/expectedChart/valuesWithDestination.yaml
@@ -151,8 +151,3 @@ workloads:
           value: null
       type: TenantOperation
       image: null
-tenantOperations:
-  provisioning: []
-  upgrade: []
-  deprovisioning: []
-contentJobs: []

--- a/test/files/expectedChart/valuesWithDestination.yaml
+++ b/test/files/expectedChart/valuesWithDestination.yaml
@@ -134,7 +134,7 @@ workloads:
       - bookshop-uaa-bind
       - bookshop-saas-registry-bind
       - bookshop-html5-repo-host-bind
-    deploymentDefinition:
+    jobDefinition:
       type: Content
       image: null
   tenant-job:
@@ -145,7 +145,7 @@ workloads:
       - bookshop-uaa-bind
       - bookshop-saas-registry-bind
       - bookshop-service-manager-bind
-    deploymentDefinition:
+    jobDefinition:
       env:
         - name: CDS_CONFIG
           value: null

--- a/test/files/expectedChart/valuesWithMTA.yaml
+++ b/test/files/expectedChart/valuesWithMTA.yaml
@@ -205,8 +205,3 @@ workloads:
       env:
         - name: TENANT_HOST_PATTERN
           value: ^(.*)-${default-uri}
-tenantOperations:
-  provisioning: []
-  upgrade: []
-  deprovisioning: []
-contentJobs: []


### PR DESCRIPTION
The change for adding tenantOperation and content job workload got pushed an accidently to main via commit - https://github.com/cap-js/cap-operator-plugin/commit/1cdd0b9a862429d73705b577fad170b1c74a2058. This PR fixes a small issue in that commit. 

Also, removed tenantOperations and ContentJobs from the default values.yaml because the webhook would throw an error if present but left empty. So better not to add it. If required, the application can add it manually.
