### PR TITLE
chore: adapt license entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/cap-js/cap-operator-plugin/issues"
   },
   "author": "SAP SE (https://www.sap.com)",
-  "license": "SEE LICENSE",
+  "license": "Apache-2.0",
   "bin": {
     "cap-op-plugin": "bin/cap-op-plugin.js"
   },


### PR DESCRIPTION
Replaces the placeholder value "SEE LICENSE" with "Apache-2.0" as the project is licensed under Apache 2.0, and the LICENSE file contains the full license text.