### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cap-js/cap-operator-plugin/security/code-scanning/2](https://github.com/cap-js/cap-operator-plugin/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out code, setting up Node.js, running tests, and performing a SonarCloud scan, it only requires `contents: read` permissions. We will add this block at the root level of the workflow to apply it to all jobs. If any job requires additional permissions in the future, they can be specified individually.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
