### PR TITLE
[Fix] Removed redundant `oauth2-configuration.redirect-uris` and `TENANT_HOST_PATTERN` from the generated `runtime-values.yaml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/). The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.9.0 - 08-September-2025
+
+### Fixed
+
+- Removed redundant `oauth2-configuration.redirect-uris` and `TENANT_HOST_PATTERN` from the generated `runtime-values.yaml` file as it is now handled in the corresponding templates.
+
 ## Version 0.8.0 - 20-August-2025
 
 ### Added

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -227,14 +227,6 @@ function updateWorkloadEnv(runtimeValuesYaml, valuesYaml, answerStruct) {
         if (workloadDetails?.jobDefinition?.type === 'TenantOperation' && answerStruct['hanaInstanceId']) {
             updateCdsConfigEnv(runtimeValuesYaml, workloadKey, 'jobDefinition', cdsConfigHana)
         }
-
-        if (workloadDetails?.deploymentDefinition?.type === 'Router') {
-            const index = runtimeValuesYaml['workloads'][workloadKey]['deploymentDefinition']['env'].findIndex(e => e.name === 'TENANT_HOST_PATTERN')
-            if (index > -1)
-                runtimeValuesYaml['workloads'][workloadKey]['deploymentDefinition']['env'][index] = { name: 'TENANT_HOST_PATTERN', value: '^(.*).' + answerStruct["appName"] + '.' + answerStruct["clusterDomain"] }
-            else
-                runtimeValuesYaml['workloads'][workloadKey]['deploymentDefinition']['env'].push({ name: 'TENANT_HOST_PATTERN', value: '^(.*).' + answerStruct["appName"] + '.' + answerStruct["clusterDomain"] })
-        }
     }
 
     // remove workload definition where env is empty

--- a/files/runtime-values.yaml.hbs
+++ b/files/runtime-values.yaml.hbs
@@ -16,9 +16,7 @@ serviceInstances:
     {{xsuaaKeyName}}:
         parameters:
             xsappname: {{appName}}
-            oauth2-configuration:
-                redirect-uris:
-                - "https://*{{appName}}.{{clusterDomain}}/**"
+
 app:
     domains:
         primary: {{appName}}.{{clusterDomain}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cap-operator-plugin",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mustache": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Add/Build Plugin for CAP Operator",
   "homepage": "https://github.com/cap-js/cap-operator-plugin/blob/main/README.md",
   "repository": {

--- a/test/files/expectedChart/runtime-values-svc.yaml
+++ b/test/files/expectedChart/runtime-values-svc.yaml
@@ -11,9 +11,6 @@ serviceInstances:
   xsuaa:
     parameters:
       xsappname: bkshop
-      oauth2-configuration:
-        redirect-uris:
-          - https://*bkshop.c-abc.kyma.ondemand.com/**
 app:
   domains:
     primary: bkshop.c-abc.kyma.ondemand.com

--- a/test/files/expectedChart/runtime-values.yaml
+++ b/test/files/expectedChart/runtime-values.yaml
@@ -11,9 +11,6 @@ serviceInstances:
   xsuaa:
     parameters:
       xsappname: bkshop
-      oauth2-configuration:
-        redirect-uris:
-          - https://*bkshop.c-abc.kyma.ondemand.com/**
 app:
   domains:
     primary: bkshop.c-abc.kyma.ondemand.com
@@ -29,11 +26,6 @@ btp:
 imagePullSecrets:
   - regcred
 workloads:
-  appRouter:
-    deploymentDefinition:
-      env:
-        - name: TENANT_HOST_PATTERN
-          value: ^(.*).bkshop.c-abc.kyma.ondemand.com
   server:
     deploymentDefinition:
       env:

--- a/test/files/expectedConfigurableTemplatesChart/runtime-values.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/runtime-values.yaml
@@ -11,9 +11,6 @@ serviceInstances:
   xsuaa:
     parameters:
       xsappname: bkshop
-      oauth2-configuration:
-        redirect-uris:
-          - https://*bkshop.c-abc.kyma.ondemand.com/**
 app:
   domains:
     primary: bkshop.c-abc.kyma.ondemand.com

--- a/test/files/runtime-values-of-simple-chart.yaml
+++ b/test/files/runtime-values-of-simple-chart.yaml
@@ -11,9 +11,6 @@ serviceInstances:
   xsuaa:
     parameters:
       xsappname: bkshop
-      oauth2-configuration:
-        redirect-uris:
-          - https://*bkshop.c-abc.kyma.ondemand.com/**
 app:
   domains:
     primary: bkshop.c-abc.kyma.ondemand.com
@@ -29,11 +26,6 @@ btp:
 imagePullSecrets:
   - regcred
 workloads:
-  appRouter:
-    deploymentDefinition:
-      env:
-        - name: TENANT_HOST_PATTERN
-          value: ^(.*).bkshop.c-abc.kyma.ondemand.com
   server:
     deploymentDefinition:
       env:


### PR DESCRIPTION
Removed redundant `oauth2-configuration.redirect-uris` and `TENANT_HOST_PATTERN` from the generated `runtime-values.yaml` file, as it is now handled in the corresponding templates.