### PR TITLE
[Misc] Conditional logging for helm chart generation message

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -109,7 +109,9 @@ module.exports = class CapOperatorAddPlugin extends cds.add.Plugin {
         }
 
         await this.updateXsSecurity(project)
-        console.log("Once values.yaml is updated, run 'cds build' to generate the helm chart. You can find the generated chart in the 'gen' folder within your project directory.")
+        if (!isConfigurable && !withTemplates) {
+            console.log("Once values.yaml is updated, run 'cds build' to generate the helm chart. You can find the generated chart in the 'gen' folder within your project directory.")
+        }
     }
 
     async combine() {


### PR DESCRIPTION
# Conditional Logging for Helm Chart Generation Message

### Bug Fix

🐛 Fixed an unnecessary log message being displayed unconditionally during helm chart generation. The message instructing users to run `cds build` is now only shown when applicable — specifically when the chart is neither configurable nor generated with templates.

### Changes

* `lib/add.js`: Wrapped the `"Once values.yaml is updated, run 'cds build'..."` console log in a conditional check so it only prints when `isConfigurable` is `false` and `withTemplates` is `false`. This avoids showing a misleading or irrelevant message in configurable chart or template-based scenarios.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.19.9` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `bd1d6ca0-2c3f-11f1-9133-bd2d10117470`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
