### PR TITLE
[Misc] Enhance template handling during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Depending on whether you used `--with-configurable-templates`, the design-time s
    > If you've already added the `templates` folder during the initial plugin call using `--with-templates` or `--with-configurable-templates` option, you can skip this step as the Helm chart is already complete.
 
    > **Custom templates**: If you place files in the `chart/templates` folder, the build handles them as follows:
-   > - A file with the **same name** as a plugin-generated template (e.g. `_helpers.tpl`, `domain.yaml`, `cap-operator-cros.yaml`, `service-binding.yaml`, `service-instance.yaml`) will be used as-is instead of the plugin's default, and a message is printed to indicate this.
-   > - Any **additional files** you add to `chart/templates` are copied alongside the standard templates without modification.
+   > - A file with the **same name** as one of the plugin-generated templates (`_helpers.tpl`, `domain.yaml`, `cap-operator-cros.yaml`, `service-binding.yaml`, `service-instance.yaml`) will be used as-is instead of the plugin's default, and a message is printed to indicate this.
+   > - Any **additional files** you add to `chart/templates` (i.e. files with names not in the list above) are copied alongside the standard templates without modification.
 
 2. Up to this point, you've only filled in the design time information in the chart. But to deploy the application, you need to create a `runtime-values.yaml` file with all the runtime values, as mentioned in the section on configuration. You can generate the file using the plugin itself.
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Depending on whether you used `--with-configurable-templates`, the design-time s
 
    > If you've already added the `templates` folder during the initial plugin call using `--with-templates` or `--with-configurable-templates` option, you can skip this step as the Helm chart is already complete.
 
+   > **Custom templates**: If you place files in the `chart/templates` folder, the build handles them as follows:
+   > - A file with the **same name** as a plugin-generated template (e.g. `_helpers.tpl`, `domain.yaml`, `cap-operator-cros.yaml`, `service-binding.yaml`, `service-instance.yaml`) will be used as-is instead of the plugin's default, and a message is printed to indicate this.
+   > - Any **additional files** you add to `chart/templates` are copied alongside the standard templates without modification.
+
 2. Up to this point, you've only filled in the design time information in the chart. But to deploy the application, you need to create a `runtime-values.yaml` file with all the runtime values, as mentioned in the section on configuration. You can generate the file using the plugin itself.
 
     The plugin requires the following information to generate the `runtime-values.yaml`:

--- a/lib/build.js
+++ b/lib/build.js
@@ -10,9 +10,11 @@ const { exists, path } = cds.utils
 const {
     isServiceOnlyChart,
     getCAPOpCroYaml,
+    getConfigurableCapOpCroYaml,
     getServiceInstanceKeyName,
     getDomainCroYaml,
-    getHelperTpl
+    getHelperTpl,
+    isConfigurableTemplateChart
 } = require('./util')
 
 module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
@@ -37,6 +39,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
         const userTemplatesDir = path.join(this.task.src, 'chart/templates')
         const destTemplatesDir = path.join(this.task.dest, 'templates')
         const hasUserTemplates = exists(userTemplatesDir)
+        const isConfigurableTempChart = isConfigurableTemplateChart(path.join(this.task.src, 'chart'))
         const customTemplateMsg = (name) => `[cap-operator-plugin] Using updated template '${name}' from chart/templates/`
         const defaultTemplateMsg = (name) => `[cap-operator-plugin] Using default template for '${name}'`
 
@@ -56,14 +59,14 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
             staticEntry('service-instance.yaml'),
             generatedEntry('_helpers.tpl', () => getHelperTpl({ hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null })),
             generatedEntry('domain.yaml', () => getDomainCroYaml({ hasIas })),
-            generatedEntry('cap-operator-cros.yaml', () => getCAPOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }))
+            generatedEntry('cap-operator-cros.yaml', () => isConfigurableTempChart ? getConfigurableCapOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }) : getCAPOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }))
         ]
 
         for (const { name, getDefault, writeDefault } of templates) {
             const userFile = path.join(userTemplatesDir, name)
             const destFile = path.join(destTemplatesDir, name)
             if (hasUserTemplates && exists(userFile)) {
-                const [userContent, defaultContent] = await Promise.all([cds.utils.read(userFile), Promise.resolve(getDefault())])
+                const [userContent, defaultContent] = await Promise.all([cds.utils.read(userFile), getDefault()])
                 this.pushMessage(
                     userContent !== defaultContent ? customTemplateMsg(name) : defaultTemplateMsg(name),
                     userContent !== defaultContent ? CapOperatorBuildPlugin.WARNING : CapOperatorBuildPlugin.INFO

--- a/lib/build.js
+++ b/lib/build.js
@@ -4,14 +4,13 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 const cds = require('@sap/cds-dk')
-const yaml = require('@sap/cds-foss').yaml
 const fs = require('fs')
 const { exists, path } = cds.utils
 const {
     isServiceOnlyChart,
     getCAPOpCroYaml,
     getConfigurableCapOpCroYaml,
-    getServiceInstanceKeyName,
+    getProjectFromValuesYaml,
     getDomainCroYaml,
     getHelperTpl,
     isConfigurableTemplateChart
@@ -51,15 +50,15 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
             name, getDefault: () => generate(), writeDefault: (dest) => cds.utils.write(generate()).to(dest)
         })
 
-        const valuesYaml = yaml.parse(await cds.utils.read(path.join(this.task.src, 'chart/values.yaml')))
-        const hasIas = getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'identity') != null
+        const isService = isServiceOnlyChart('chart')
+        const project = await getProjectFromValuesYaml(path.join(this.task.src, 'chart'), isService)
 
         const templates = [
             staticEntry('service-binding.yaml'),
             staticEntry('service-instance.yaml'),
-            generatedEntry('_helpers.tpl', () => getHelperTpl({ hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null }, isConfigurableTempChart)),
-            generatedEntry('domain.yaml', () => getDomainCroYaml({ hasIas })),
-            generatedEntry('cap-operator-cros.yaml', () => isConfigurableTempChart ? getConfigurableCapOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }) : getCAPOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }))
+            generatedEntry('_helpers.tpl', () => getHelperTpl(project, isConfigurableTempChart)),
+            generatedEntry('domain.yaml', () => getDomainCroYaml(project)),
+            generatedEntry('cap-operator-cros.yaml', () => isConfigurableTempChart ? getConfigurableCapOpCroYaml(project) : getCAPOpCroYaml(project))
         ]
 
         for (const { name, getDefault, writeDefault } of templates) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -57,7 +57,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
         const templates = [
             staticEntry('service-binding.yaml'),
             staticEntry('service-instance.yaml'),
-            generatedEntry('_helpers.tpl', () => getHelperTpl({ hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null })),
+            generatedEntry('_helpers.tpl', () => getHelperTpl({ hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null }, isConfigurableTempChart)),
             generatedEntry('domain.yaml', () => getDomainCroYaml({ hasIas })),
             generatedEntry('cap-operator-cros.yaml', () => isConfigurableTempChart ? getConfigurableCapOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }) : getCAPOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }))
         ]

--- a/lib/build.js
+++ b/lib/build.js
@@ -37,7 +37,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
         const userTemplatesDir = path.join(this.task.src, 'chart/templates')
         const destTemplatesDir = path.join(this.task.dest, 'templates')
         const hasUserTemplates = exists(userTemplatesDir)
-        const customTemplateMsg = (name) => `[cap-operator-plugin] Using template '${name}' from chart/templates/`
+        const customTemplateMsg = (name) => `[cap-operator-plugin] Using updated template '${name}' from chart/templates/`
         const defaultTemplateMsg = (name) => `[cap-operator-plugin] Using default template for '${name}'`
 
         const staticEntry = (name) => {

--- a/lib/build.js
+++ b/lib/build.js
@@ -38,6 +38,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
         const destTemplatesDir = path.join(this.task.dest, 'templates')
         const hasUserTemplates = exists(userTemplatesDir)
         const customTemplateMsg = (name) => `[cap-operator-plugin] Using template '${name}' from chart/templates/`
+        const defaultTemplateMsg = (name) => `[cap-operator-plugin] Using default template for '${name}'`
 
         for (const name of ['service-binding.yaml', 'service-instance.yaml']) {
             const userFile = path.join(userTemplatesDir, name)
@@ -45,6 +46,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
                 console.log(customTemplateMsg(name))
                 await this.copy(userFile).to(path.join(destTemplatesDir, name))
             } else {
+                console.log(defaultTemplateMsg(name))
                 await this.copy(path.join(__dirname, `../files/commonTemplates/${name}`)).to(path.join(destTemplatesDir, name))
             }
         }
@@ -73,6 +75,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
                 console.log(customTemplateMsg(name))
                 await this.copy(userFile).to(path.join(destTemplatesDir, name))
             } else {
+                console.log(defaultTemplateMsg(name))
                 await cds.utils.write(generate()).to(path.join(destTemplatesDir, name))
             }
         }
@@ -81,6 +84,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
             const knownFiles = new Set(['service-binding.yaml', 'service-instance.yaml', '_helpers.tpl', 'domain.yaml', 'cap-operator-cros.yaml'])
             for (const entry of await fs.promises.readdir(userTemplatesDir)) {
                 if (!knownFiles.has(entry)) {
+                    console.log(`[cap-operator-plugin] Copying user defined template '${entry}' from chart/templates/`)
                     await this.copy(path.join(userTemplatesDir, entry)).to(path.join(destTemplatesDir, entry))
                 }
             }
@@ -101,6 +105,8 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
     }
 
     async build() {
+        console.log(`[cap-operator-plugin] Generating Helm chart in ${this.task.dest}...`)
+
         // Copy templates
         await this.copyTemplates()
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -40,43 +40,38 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
         const customTemplateMsg = (name) => `[cap-operator-plugin] Using template '${name}' from chart/templates/`
         const defaultTemplateMsg = (name) => `[cap-operator-plugin] Using default template for '${name}'`
 
-        for (const name of ['service-binding.yaml', 'service-instance.yaml']) {
-            const userFile = path.join(userTemplatesDir, name)
-            if (hasUserTemplates && exists(userFile)) {
-                console.log(customTemplateMsg(name))
-                await this.copy(userFile).to(path.join(destTemplatesDir, name))
-            } else {
-                console.log(defaultTemplateMsg(name))
-                await this.copy(path.join(__dirname, `../files/commonTemplates/${name}`)).to(path.join(destTemplatesDir, name))
-            }
+        const staticEntry = (name) => {
+            const defaultFile = path.join(__dirname, `../files/commonTemplates/${name}`)
+            return { name, getDefault: () => cds.utils.read(defaultFile), writeDefault: (dest) => this.copy(defaultFile).to(dest) }
         }
+        const generatedEntry = (name, generate) => ({
+            name, getDefault: () => generate(), writeDefault: (dest) => cds.utils.write(generate()).to(dest)
+        })
 
         const valuesYaml = yaml.parse(await cds.utils.read(path.join(this.task.src, 'chart/values.yaml')))
         const hasIas = getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'identity') != null
 
-        const generatedFiles = [
-            {
-                name: '_helpers.tpl',
-                generate: () => getHelperTpl({ hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null })
-            },
-            {
-                name: 'domain.yaml',
-                generate: () => getDomainCroYaml({ hasIas })
-            },
-            {
-                name: 'cap-operator-cros.yaml',
-                generate: () => getCAPOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') })
-            }
+        const templates = [
+            staticEntry('service-binding.yaml'),
+            staticEntry('service-instance.yaml'),
+            generatedEntry('_helpers.tpl', () => getHelperTpl({ hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null })),
+            generatedEntry('domain.yaml', () => getDomainCroYaml({ hasIas })),
+            generatedEntry('cap-operator-cros.yaml', () => getCAPOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') }))
         ]
 
-        for (const { name, generate } of generatedFiles) {
+        for (const { name, getDefault, writeDefault } of templates) {
             const userFile = path.join(userTemplatesDir, name)
+            const destFile = path.join(destTemplatesDir, name)
             if (hasUserTemplates && exists(userFile)) {
-                console.log(customTemplateMsg(name))
-                await this.copy(userFile).to(path.join(destTemplatesDir, name))
+                const [userContent, defaultContent] = await Promise.all([cds.utils.read(userFile), Promise.resolve(getDefault())])
+                this.pushMessage(
+                    userContent !== defaultContent ? customTemplateMsg(name) : defaultTemplateMsg(name),
+                    userContent !== defaultContent ? CapOperatorBuildPlugin.WARNING : CapOperatorBuildPlugin.INFO
+                )
+                await this.copy(userFile).to(destFile)
             } else {
-                console.log(defaultTemplateMsg(name))
-                await cds.utils.write(generate()).to(path.join(destTemplatesDir, name))
+                this.pushMessage(defaultTemplateMsg(name), CapOperatorBuildPlugin.INFO)
+                await writeDefault(destFile)
             }
         }
 
@@ -84,7 +79,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
             const knownFiles = new Set(['service-binding.yaml', 'service-instance.yaml', '_helpers.tpl', 'domain.yaml', 'cap-operator-cros.yaml'])
             for (const entry of await fs.promises.readdir(userTemplatesDir)) {
                 if (!knownFiles.has(entry)) {
-                    console.log(`[cap-operator-plugin] Copying user defined template '${entry}' from chart/templates/`)
+                    this.pushMessage(`[cap-operator-plugin] Copying user defined template '${entry}' from chart/templates/`, CapOperatorBuildPlugin.INFO)
                     await this.copy(path.join(userTemplatesDir, entry)).to(path.join(destTemplatesDir, entry))
                 }
             }
@@ -105,7 +100,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
     }
 
     async build() {
-        console.log(`[cap-operator-plugin] Generating Helm chart in ${this.task.dest}...`)
+        this.pushMessage(`[cap-operator-plugin] Generating Helm chart in ${this.task.dest}...`, CapOperatorBuildPlugin.INFO)
 
         // Copy templates
         await this.copyTemplates()

--- a/lib/build.js
+++ b/lib/build.js
@@ -7,7 +7,6 @@ const cds = require('@sap/cds-dk')
 const fs = require('fs')
 const { exists, path } = cds.utils
 const {
-    isServiceOnlyChart,
     getCAPOpCroYaml,
     getConfigurableCapOpCroYaml,
     getProjectFromValuesYaml,
@@ -50,8 +49,7 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
             name, getDefault: () => generate(), writeDefault: (dest) => cds.utils.write(generate()).to(dest)
         })
 
-        const isService = isServiceOnlyChart('chart')
-        const project = await getProjectFromValuesYaml(path.join(this.task.src, 'chart'), isService)
+        const project = await getProjectFromValuesYaml(path.join(this.task.src, 'chart'))
 
         const templates = [
             staticEntry('service-binding.yaml'),

--- a/lib/build.js
+++ b/lib/build.js
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 const cds = require('@sap/cds-dk')
 const yaml = require('@sap/cds-foss').yaml
+const fs = require('fs')
 const { exists, path } = cds.utils
 const {
     isServiceOnlyChart,
@@ -33,32 +34,57 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
     }
 
     async copyTemplates() {
-        if (exists(path.join(this.task.src, 'chart/templates'))) {
-            return await this.copy(path.join(this.task.src, 'chart/templates')).to(path.join(this.task.dest, 'templates'))
+        const userTemplatesDir = path.join(this.task.src, 'chart/templates')
+        const destTemplatesDir = path.join(this.task.dest, 'templates')
+        const hasUserTemplates = exists(userTemplatesDir)
+        const customTemplateMsg = (name) => `[cap-operator-plugin] Using template '${name}' from chart/templates/`
+
+        for (const name of ['service-binding.yaml', 'service-instance.yaml']) {
+            const userFile = path.join(userTemplatesDir, name)
+            if (hasUserTemplates && exists(userFile)) {
+                console.log(customTemplateMsg(name))
+                await this.copy(userFile).to(path.join(destTemplatesDir, name))
+            } else {
+                await this.copy(path.join(__dirname, `../files/commonTemplates/${name}`)).to(path.join(destTemplatesDir, name))
+            }
         }
 
-        await this.copy(path.join(__dirname, '../files/commonTemplates/')).to(path.join(this.task.dest, 'templates/'))
-
         const valuesYaml = yaml.parse(await cds.utils.read(path.join(this.task.src, 'chart/values.yaml')))
-
-        // Create _helpers.tpl
-        await cds.utils.write(getHelperTpl({
-            hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null
-        })).to(path.join(this.task.dest, 'templates/_helpers.tpl'))
-
         const hasIas = getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'identity') != null
 
-        // Create domain.yaml
-        await cds.utils.write(getDomainCroYaml({
-            hasIas: hasIas
-        })).to(path.join(this.task.dest, 'templates/domain.yaml'))
+        const generatedFiles = [
+            {
+                name: '_helpers.tpl',
+                generate: () => getHelperTpl({ hasXsuaa: getServiceInstanceKeyName(valuesYaml['serviceInstances'], 'xsuaa') != null })
+            },
+            {
+                name: 'domain.yaml',
+                generate: () => getDomainCroYaml({ hasIas })
+            },
+            {
+                name: 'cap-operator-cros.yaml',
+                generate: () => getCAPOpCroYaml({ hasIas, isService: isServiceOnlyChart('chart') })
+            }
+        ]
 
-        // Create cap-operator-cros.yaml
-        // Only filling those fields in the project input struct that are required to create CAPApplication
-        await cds.utils.write(getCAPOpCroYaml({
-            hasIas: hasIas,
-            isService: isServiceOnlyChart('chart')
-        })).to(path.join(this.task.dest, 'templates/cap-operator-cros.yaml'))
+        for (const { name, generate } of generatedFiles) {
+            const userFile = path.join(userTemplatesDir, name)
+            if (hasUserTemplates && exists(userFile)) {
+                console.log(customTemplateMsg(name))
+                await this.copy(userFile).to(path.join(destTemplatesDir, name))
+            } else {
+                await cds.utils.write(generate()).to(path.join(destTemplatesDir, name))
+            }
+        }
+
+        if (hasUserTemplates) {
+            const knownFiles = new Set(['service-binding.yaml', 'service-instance.yaml', '_helpers.tpl', 'domain.yaml', 'cap-operator-cros.yaml'])
+            for (const entry of await fs.promises.readdir(userTemplatesDir)) {
+                if (!knownFiles.has(entry)) {
+                    await this.copy(path.join(userTemplatesDir, entry)).to(path.join(destTemplatesDir, entry))
+                }
+            }
+        }
     }
 
     async copyChartYaml() {

--- a/lib/build.js
+++ b/lib/build.js
@@ -67,9 +67,11 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
             const destFile = path.join(destTemplatesDir, name)
             if (hasUserTemplates && exists(userFile)) {
                 const [userContent, defaultContent] = await Promise.all([cds.utils.read(userFile), getDefault()])
+                const userStr = userContent?.toString()
+                const defaultStr = defaultContent?.toString()
                 this.pushMessage(
-                    userContent !== defaultContent ? customTemplateMsg(name) : defaultTemplateMsg(name),
-                    userContent !== defaultContent ? CapOperatorBuildPlugin.WARNING : CapOperatorBuildPlugin.INFO
+                    userStr !== defaultStr ? customTemplateMsg(name) : defaultTemplateMsg(name),
+                    userStr !== defaultStr ? CapOperatorBuildPlugin.WARNING : CapOperatorBuildPlugin.INFO
                 )
                 await this.copy(userFile).to(destFile)
             } else {
@@ -80,10 +82,10 @@ module.exports = class CapOperatorBuildPlugin extends cds.build.Plugin {
 
         if (hasUserTemplates) {
             const knownFiles = new Set(['service-binding.yaml', 'service-instance.yaml', '_helpers.tpl', 'domain.yaml', 'cap-operator-cros.yaml'])
-            for (const entry of await fs.promises.readdir(userTemplatesDir)) {
-                if (!knownFiles.has(entry)) {
-                    this.pushMessage(`[cap-operator-plugin] Copying user defined template '${entry}' from chart/templates/`, CapOperatorBuildPlugin.INFO)
-                    await this.copy(path.join(userTemplatesDir, entry)).to(path.join(destTemplatesDir, entry))
+            for (const entry of await fs.promises.readdir(userTemplatesDir, { withFileTypes: true })) {
+                if (entry.isDirectory() || !knownFiles.has(entry.name)) {
+                    this.pushMessage(`[cap-operator-plugin] Copying user defined template '${entry.name}' from chart/templates/`, CapOperatorBuildPlugin.INFO)
+                    await this.copy(path.join(userTemplatesDir, entry.name)).to(path.join(destTemplatesDir, entry.name))
                 }
             }
         }

--- a/lib/util.js
+++ b/lib/util.js
@@ -216,6 +216,24 @@ function getServiceInstanceKeyName(serviceInstances, offeringName) {
   ) ?? null
 }
 
+async function getProjectFromValuesYaml(chartPath, isService) {
+  const valuesYaml = yaml.parse(await cds.utils.read(cds.utils.path.join(chartPath, 'values.yaml')))
+  const chartYaml = yaml.parse(await cds.utils.read(cds.utils.path.join(chartPath, 'Chart.yaml')))
+  const si = valuesYaml['serviceInstances']
+  const has = offering => getServiceInstanceKeyName(si, offering) != null
+  return {
+    isService,
+    appName: chartYaml.name,
+    hasXsuaa: has('xsuaa'),
+    hasIas: has('identity'),
+    hasDestination: has('destination'),
+    hasHtml5Repo: has('html5-apps-repo'),
+    hasMultitenancy: has('saas-registry') || has('subscription-manager'),
+    hasApprouter: valuesYaml.workloads?.appRouter != null,
+    hasAms: valuesYaml.workloads?.amsDeployer != null,
+  }
+}
+
 function yamlBuilder() {
   const lines = []
   let indent = 0
@@ -739,6 +757,7 @@ module.exports = {
   transformValuesAndFillCapOpCroYaml,
   convertHypenNameToCamelcase,
   getServiceInstanceKeyName,
+  getProjectFromValuesYaml,
   getConfigurableCapOpCroYaml,
   getCAPOpCroYaml,
   getDomainCroYaml,

--- a/lib/util.js
+++ b/lib/util.js
@@ -216,13 +216,13 @@ function getServiceInstanceKeyName(serviceInstances, offeringName) {
   ) ?? null
 }
 
-async function getProjectFromValuesYaml(chartPath, isService) {
+async function getProjectFromValuesYaml(chartPath) {
   const valuesYaml = yaml.parse(await cds.utils.read(cds.utils.path.join(chartPath, 'values.yaml')))
   const chartYaml = yaml.parse(await cds.utils.read(cds.utils.path.join(chartPath, 'Chart.yaml')))
   const si = valuesYaml['serviceInstances']
   const has = offering => getServiceInstanceKeyName(si, offering) != null
   return {
-    isService,
+    isService: chartYaml.annotations?.["app.kubernetes.io/component"] === 'service-only' || false,
     appName: chartYaml.name,
     hasXsuaa: has('xsuaa'),
     hasIas: has('identity'),

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -47,6 +47,23 @@ describe('cds build', () => {
 
     })
 
+    it('Build cap-operator chart with user-defined custom template', async () => {
+        execSync(`cds add cap-operator`, { cwd: bookshop })
+
+        fs.mkdirSync(join(bookshop, 'chart/templates'), { recursive: true })
+        fs.writeFileSync(join(bookshop, 'chart/templates/my-custom-template.yaml'), '# custom user template\n')
+
+        execSync(`cds build`, { cwd: bookshop })
+
+        expect(fs.readFileSync(join(bookshop, 'gen/chart/templates/my-custom-template.yaml'), 'utf8')).to.equal('# custom user template\n')
+
+        expect(fs.existsSync(join(bookshop, 'gen/chart/templates/_helpers.tpl'))).to.equal(true)
+        expect(fs.existsSync(join(bookshop, 'gen/chart/templates/domain.yaml'))).to.equal(true)
+        expect(fs.existsSync(join(bookshop, 'gen/chart/templates/cap-operator-cros.yaml'))).to.equal(true)
+        expect(fs.existsSync(join(bookshop, 'gen/chart/templates/service-binding.yaml'))).to.equal(true)
+        expect(fs.existsSync(join(bookshop, 'gen/chart/templates/service-instance.yaml'))).to.equal(true)
+    })
+
     it('Build cap-operator chart with modified templates', async () => {
         execSync(`cds add cap-operator --with-templates`, { cwd: bookshop })
 
@@ -64,6 +81,6 @@ describe('cds build', () => {
         expect(getFileHash(join(__dirname,'../files/commonTemplates/service-instance.yaml'))).to.equal(getFileHash(join(bookshop, 'gen/chart/templates/service-instance.yaml')))
         expect(getFileHash(join(__dirname,'files/domain.yaml'))).to.equal(getFileHash(join(bookshop, 'gen/chart/templates/domain.yaml')))
 
-        expect(fs.existsSync(join(bookshop, 'gen/chart/templates/_helpers.tpl'))).to.equal(false)
+        expect(fs.existsSync(join(bookshop, 'gen/chart/templates/_helpers.tpl'))).to.equal(true)
     })
 })

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -48,14 +48,17 @@ describe('cds build', () => {
     })
 
     it('Build cap-operator chart with user-defined custom template', async () => {
+        execSync(`rm -rf gen`, { cwd: bookshop })
         execSync(`cds add cap-operator`, { cwd: bookshop })
 
-        fs.mkdirSync(join(bookshop, 'chart/templates'), { recursive: true })
+        fs.mkdirSync(join(bookshop, 'chart/templates/my-subdir'), { recursive: true })
         fs.writeFileSync(join(bookshop, 'chart/templates/my-custom-template.yaml'), '# custom user template\n')
+        fs.writeFileSync(join(bookshop, 'chart/templates/my-subdir/my-nested-template.yaml'), '# custom nested template\n')
 
         execSync(`cds build`, { cwd: bookshop })
 
         expect(fs.readFileSync(join(bookshop, 'gen/chart/templates/my-custom-template.yaml'), 'utf8')).to.equal('# custom user template\n')
+        expect(fs.readFileSync(join(bookshop, 'gen/chart/templates/my-subdir/my-nested-template.yaml'), 'utf8')).to.equal('# custom nested template\n')
 
         expect(fs.existsSync(join(bookshop, 'gen/chart/templates/_helpers.tpl'))).to.equal(true)
         expect(fs.existsSync(join(bookshop, 'gen/chart/templates/domain.yaml'))).to.equal(true)


### PR DESCRIPTION
# Enhance Template Handling During `cds build`

### New Feature

✨ Improved the `cds build` process to give developers more control over Helm chart templates. Instead of blindly overriding or skipping plugin-generated templates, the build now intelligently handles user-provided templates in `chart/templates/`:

- If a file with the **same name** as a plugin-generated template exists (`_helpers.tpl`, `domain.yaml`, `cap-operator-cros.yaml`, `service-binding.yaml`, `service-instance.yaml`), the user's version is used and a **warning** is emitted.
- If the user's file matches the plugin default, an **info** message is logged instead.
- Any **additional/custom files** in `chart/templates/` not matching known plugin templates are copied alongside the standard templates.
- A build start message is now emitted at the beginning of the `build()` method for better observability.

### Changes

* `lib/build.js`: Refactored `copyTemplates()` to use `staticEntry`/`generatedEntry` helpers modeling each known template. The method now compares user-provided templates against plugin defaults, logs appropriate messages, and copies extra user-defined files. Added `fs` module for directory reading, and imported `getConfigurableCapOpCroYaml`, `isConfigurableTemplateChart`, and `getProjectFromValuesYaml` from `util`.
* `lib/util.js`: Added `getProjectFromValuesYaml()` helper function that reads `values.yaml` and `Chart.yaml` to build a normalized project descriptor object, consolidating logic previously scattered across `build.js`. Exported the new function.
* `README.md`: Added documentation clarifying how custom files in `chart/templates` are handled during `cds build`, distinguishing between same-name overrides and additional files.
* `test/build.test.js`: Added a new test case verifying that custom user-defined templates (including nested subdirectories) are copied into the generated chart while all standard plugin templates are still present. Fixed an existing test: a deleted `_helpers.tpl` in `--with-templates` mode now correctly expects the plugin to regenerate it (assertion changed from `false` to `true`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Event Trigger: `pull_request.edited`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `0b57b9c5-4336-47bf-9636-77c03d3d45da`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
