### PR TITLE
[Misc] workflow: Use build environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     name: Analyze with Sonar Cloud
     needs: build
     runs-on: ubuntu-latest
+    environment: build
     steps:
     - name: Check out code for Sonar Analysis
       uses: actions/checkout@v4
@@ -48,5 +49,4 @@ jobs:
     - name: SonarCloud Scan
       uses: SonarSource/sonarcloud-github-action@master
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
# Workflow: Scope Sonar Secret to Build Environment

### Chore

🔧 Updated the CI workflow to associate the SonarCloud analysis job with the `build` environment, ensuring the `SONAR_TOKEN` secret is scoped to that environment. The redundant `GITHUB_TOKEN` secret reference has also been removed from the SonarCloud scan step.

### Changes

* `.github/workflows/ci.yml`: Added `environment: build` to the `analysis` job so the `SONAR_TOKEN` secret is resolved from the `build` environment. Removed the now-unnecessary `GITHUB_TOKEN` environment variable from the SonarCloud scan step.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `b986f8a2-4a17-4a77-839d-f7843f4981fa`
</details>
