### PR TITLE
[Misc] Workflow: action versions updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         node-version: [lts/*, lts/-1]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm i -g @sap/cds-dk
@@ -35,10 +35,10 @@ jobs:
     environment: build
     steps:
     - name: Check out code for Sonar Analysis
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: lts/*
     - name: run coverage tests
@@ -47,6 +47,6 @@ jobs:
         npm i
         npm run test-coverage-lcov
     - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@v8
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
         registry-url: https://registry.npmjs.org/
@@ -24,10 +24,10 @@ jobs:
         npm run test
     - name: get version
       id: package-version
-      uses: martinbeentjes/npm-get-version-action@v1.2.3
+      uses: martinbeentjes/npm-get-version-action@v1.3.1
     - name: parse changelog
       id: parse-changelog
-      uses: schwma/parse-changelog-action@v1.0.0
+      uses: schwma/parse-changelog-action@v1.2.0
       with:
         version: '${{ steps.package-version.outputs.current-version }}'
     - name: create a GitHub release


### PR DESCRIPTION
# Update GitHub Actions Workflow Versions

### Chore

🔧 Updated GitHub Actions workflow dependencies to their latest versions across CI and release pipelines.

### Changes

* `.github/workflows/ci.yml`:
  - Updated `actions/checkout` from `v4` to `v6`
  - Updated `actions/setup-node` from `v4` to `v6`
  - Replaced `SonarSource/sonarcloud-github-action@master` with `SonarSource/sonarqube-scan-action@v8`

* `.github/workflows/release.yml`:
  - Updated `actions/checkout` from `v4` to `v6`
  - Updated `actions/setup-node` from `v4` to `v6`
  - Updated `martinbeentjes/npm-get-version-action` from `v1.2.3` to `v1.3.1`
  - Updated `schwma/parse-changelog-action` from `v1.0.0` to `v1.2.0`

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.0`

- Event Trigger: `issue_comment.edited`
- Correlation ID: `4ca3031a-d7f8-404b-a734-2f00deb88f45`
</details>
