### PR TITLE
[Fix] propagate subscriptionDependency in CAPApplication templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/). The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.16.1 - 29-May-2026
+
+### Fixed
+
+- `subscriptionDependency` field from `serviceInstances` is now propagated to the `btp.services` section in the CAPApplication template.
+
 ## Version 0.16.0 - 29-May-2026
 
 ### Added

--- a/lib/util.js
+++ b/lib/util.js
@@ -314,6 +314,9 @@ function writeCAPApplicationCRO(yaml, hasIas, isService) {
         '  name: {{ $v.name | default "invalidValue" }}',
         '  {{- end }}',
         '  secret: {{ $v.secretName | default "invalidValue" }}',
+        '  {{- if hasKey $serviceInstance "subscriptionDependency" }}',
+        '  subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}',
+        '  {{- end }}',
         '{{- end }}',
         '{{- end }}'
       ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cap-operator-plugin",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Add/Build Plugin for CAP Operator",
   "homepage": "https://github.com/cap-js/cap-operator-plugin/blob/main/README.md",
   "repository": {

--- a/test/files/expectedChart/templates/cap-operator-cros-ias.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros-ias.yaml
@@ -36,6 +36,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedChart/templates/cap-operator-cros-svc-ias.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros-svc-ias.yaml
@@ -33,6 +33,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedChart/templates/cap-operator-cros-svc.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros-svc.yaml
@@ -33,6 +33,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedChart/templates/cap-operator-cros.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros.yaml
@@ -36,6 +36,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-ias.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-ias.yaml
@@ -36,6 +36,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified-svc.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified-svc.yaml
@@ -33,6 +33,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified.yaml
@@ -36,6 +36,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-mta.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-mta.yaml
@@ -36,6 +36,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc-ias.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc-ias.yaml
@@ -33,6 +33,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc.yaml
@@ -33,6 +33,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros.yaml
@@ -36,6 +36,9 @@ spec:
       name: {{ $v.name | default "invalidValue" }}
       {{- end }}
       secret: {{ $v.secretName | default "invalidValue" }}
+      {{- if hasKey $serviceInstance "subscriptionDependency" }}
+      subscriptionDependency: {{ get $serviceInstance "subscriptionDependency" }}
+      {{- end }}
     {{- end }}
     {{- end }}
 ---


### PR DESCRIPTION
# Propagate `subscriptionDependency` in CAPApplication Templates

### Bug Fix

🐛 Fixed the missing propagation of the `subscriptionDependency` field from `serviceInstances` to the `btp.services` section in generated `CAPApplication` Helm templates. When a service instance had `subscriptionDependency` configured, it was previously not included in the rendered output.

### Changes

* `lib/util.js`: Added a conditional block to emit the `subscriptionDependency` field in the `btp.services` section of the CAPApplication template when the field is present on a service instance.
* `package.json`: Bumped version from `0.16.0` to `0.16.1`.
* `CHANGELOG.md`: Added changelog entry for version `0.16.1` documenting the fix.
* `test/files/expectedChart/templates/cap-operator-cros*.yaml`: Updated all expected chart snapshot files to include the new `subscriptionDependency` conditional block.
* `test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros*.yaml`: Updated all configurable template chart snapshots similarly to reflect the fix.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.21.1`

- Correlation ID: `4e2afe54-d0f2-4cbf-a045-5ba599ed347a`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
</details>
