### PR TITLE
fix: render registrySecrets as empty array when imagePullSecrets is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Version 0.17.0 - 24-June-2026
 
-### Removed
+### Changed
 
 - `btp.provider` (`subdomain` and `tenantId`) has been removed from the generated Helm chart. The `CAPApplication` spec `provider` field is [deprecated since CAP Operator v0.31.0](https://github.com/SAP/cap-operator/releases/tag/v0.31.0). The `generate-runtime-values` command no longer prompts for `providerSubdomain` and `tenantId`.
 
 - **Use this version with CAP Operator `v0.31.0` or later.**
+
+### Fixed
+
+- `registrySecrets` in `CAPApplicationVersion` template now renders as an empty array (`[]`) when `imagePullSecrets` is not set, preventing a CRD validation failure on helm install/upgrade.
 
 ## Version 0.16.1 - 29-May-2026
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -329,9 +329,13 @@ function writeCAPApplicationVersionCommonCRO(yaml) {
     'spec:',
     '  capApplicationInstance: {{ include "appName" $ }}',
     '  version: "{{ .Values.app.version | default .Release.Revision }}"',
+    '  {{- if .Values.imagePullSecrets }}',
     '  registrySecrets:',
     '  {{- range .Values.imagePullSecrets }}',
     '  - {{ . }}',
+    '  {{- end }}',
+    '  {{- else }}',
+    '  registrySecrets: []',
     '  {{- end }}'
   ])
 }

--- a/test/files/expectedChart/templates/cap-operator-cros-ias.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros-ias.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   {{- range $k, $v := .Values.workloads }}

--- a/test/files/expectedChart/templates/cap-operator-cros-svc-ias.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros-svc-ias.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   {{- range $k, $v := .Values.workloads }}

--- a/test/files/expectedChart/templates/cap-operator-cros-svc.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros-svc.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   {{- range $k, $v := .Values.workloads }}

--- a/test/files/expectedChart/templates/cap-operator-cros.yaml
+++ b/test/files/expectedChart/templates/cap-operator-cros.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   {{- range $k, $v := .Values.workloads }}

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-ias.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-ias.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   - name: server

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified-svc.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified-svc.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   - name: server

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-modified.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   - name: app-router

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-mta.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-mta.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   - name: author-readings-approuter

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc-ias.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc-ias.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   - name: server

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros-svc.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   - name: server

--- a/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros.yaml
+++ b/test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros.yaml
@@ -49,9 +49,13 @@ metadata:
 spec:
   capApplicationInstance: {{ include "appName" $ }}
   version: "{{ .Values.app.version | default .Release.Revision }}"
+  {{- if .Values.imagePullSecrets }}
   registrySecrets:
   {{- range .Values.imagePullSecrets }}
   - {{ . }}
+  {{- end }}
+  {{- else }}
+  registrySecrets: []
   {{- end }}
   workloads:
   - name: server


### PR DESCRIPTION
# Fix: Render `registrySecrets` as Empty Array When `imagePullSecrets` is Not Set

### Bug Fix

🐛 Fixed a Helm template rendering issue where `registrySecrets` in the `CAPApplicationVersion` CRD was rendered as `null` instead of `[]` when `imagePullSecrets` was not set. This caused CRD schema validation failures during `helm install` / `helm upgrade`.

The fix wraps the `registrySecrets` block in an `{{- if .Values.imagePullSecrets }}` conditional — rendering the populated list when secrets are provided, and falling back to `registrySecrets: []` otherwise.

### Changes

* `lib/util.js`: Updated the `writeCAPApplicationVersionCommonCRO` function to conditionally render `registrySecrets` — outputting an empty array `[]` when `imagePullSecrets` is not defined.
* `test/files/expectedChart/templates/cap-operator-cros.yaml`: Updated expected test fixture to reflect the new conditional `registrySecrets` rendering.
* `test/files/expectedChart/templates/cap-operator-cros-ias.yaml`: Same fix applied to the IAS variant expected output.
* `test/files/expectedChart/templates/cap-operator-cros-svc.yaml`: Same fix applied to the service variant expected output.
* `test/files/expectedChart/templates/cap-operator-cros-svc-ias.yaml`: Same fix applied to the service IAS variant expected output.
* `test/files/expectedConfigurableTemplatesChart/templates/cap-operator-cros*.yaml`: Updated all configurable template chart expected fixtures (standard, IAS, service, service-IAS, modified, modified-service, MTA) to match the updated template behavior.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.11`

- Correlation ID: `a9acf2bf-0a7c-4742-aa1a-68bf13341f6a`
- Event Trigger: `issue_comment.edited`
</details>
