### PR TITLE
[Release] Bump version to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/). The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.18.0 - 03-July-2026
+### **Use this version with CAP Operator `v0.32.0` or later.**
+
+### Added
+
+- `rolloutOnCredentialUpdate` field to `CAPApplication` spec. When enabled, workloads are automatically redeployed when their service credentials are updated.
+
 ## Version 0.17.0 - 26-June-2026
-**Use this version with CAP Operator `v0.31.0` or later.**
+### **Use this version with CAP Operator `v0.31.0` or later.**
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cap-operator-plugin",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Add/Build Plugin for CAP Operator",
   "homepage": "https://github.com/cap-js/cap-operator-plugin/blob/main/README.md",
   "repository": {


### PR DESCRIPTION
# Release: Bump Version to 0.18.0

🔖 **Chore**: Bumps the `@cap-js/cap-operator-plugin` package version from `0.17.0` to `0.18.0` and updates the changelog with the new release entry.

### Changes

* `CHANGELOG.md`: Added release notes for `v0.18.0` (03-July-2026), noting compatibility with CAP Operator `v0.32.0` or later. Documents the new `rolloutOnCredentialUpdate` field added to `CAPApplication` spec. Also minor formatting fix for the `v0.17.0` heading.
* `package.json`: Bumped version from `0.17.0` to `0.18.0`.
* `package-lock.json`: Updated lock file to reflect the new version `0.18.0`.

### What's New in 0.18.0

- ✨ Added `rolloutOnCredentialUpdate` field to `CAPApplication` spec — when enabled, workloads are automatically redeployed when their service credentials are updated.
- ⚠️ Requires CAP Operator `v0.32.0` or later.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.26.14`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `deccaf20-76cf-11f1-89e8-4fd8b10d944e`
- Event Trigger: `pull_request.opened`
</details>
