### PR TITLE
[Feat] Implement 'add-cap-operator-skill' command to add CAP Operator agent skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/). The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.19.0 - 27-July-2026
+
+### Added
+
+- New `add-cap-operator-skill` command to download and install the CAP Operator agent skill into `.agents/skills/cap-operator/`. The skill teaches AI coding assistants (such as Claude Code) how to manage CAP Operator resources on Kubernetes.
+
 ## Version 0.18.0 - 03-July-2026
 ### **Use this version with CAP Operator `v0.32.0` or later.**
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The CAP Operator Plugin offers a simple method for generating [CAP Operator](htt
 
 ## Before You Start
 
-The CAP Operator plugin requires `@sap/cds-dk: ">=8.2.1"`. If you've installed @sap/cds-dk  globally, ensure that the installed version is `8.2.1` or higher.
+The CAP Operator plugin requires `@sap/cds-dk: ">=9"`. If you've installed @sap/cds-dk  globally, ensure that the installed version is `9` or higher.
 
 ## Set Up the Plugin
 
@@ -269,6 +269,19 @@ This downloads the skill files from the **latest release** of CAP Operator and w
     ```sh
     npx cap-op-plugin add-cap-operator-skill --branch main
     ```
+
+**Making the skill available in Claude Code**
+
+Some AI tools, including Claude Code, may not automatically detect skills placed in a project's `.agents/` folder. If the skill is not picked up automatically, paste the following prompt into Claude Code to register it globally:
+
+> Link the cap-operator skill from this project's `.agents/skills/cap-operator` folder to the central Claude skills directory so it's available globally:
+>
+> ```sh
+> mkdir -p ~/.claude/skills
+> ln -s "$(pwd)/.agents/skills/cap-operator" ~/.claude/skills/cap-operator
+> ```
+>
+> Then run `/reload-skills` in Claude Code to pick it up.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -254,21 +254,7 @@ CAP Operator ships an [agent skill](https://github.com/SAP/cap-operator/tree/mai
 npx cap-op-plugin add-cap-operator-skill
 ```
 
-This downloads the skill files from the **latest release** of CAP Operator and writes them into `.agents/skills/cap-operator/` in your project. Running the command again on a newer release cleanly replaces the skill files (orphaned files removed upstream are pruned), while leaving any other skills you keep under `.agents/` untouched.
-
-**Options**
-
-* `--version <release-version>` — Download the skill from a specific CAP Operator release instead of the latest:
-
-    ```sh
-    npx cap-op-plugin add-cap-operator-skill --version v0.33.0
-    ```
-
-* `--branch <branch-name>` — Download the skill directly from a branch (useful for testing unreleased changes):
-
-    ```sh
-    npx cap-op-plugin add-cap-operator-skill --branch main
-    ```
+This downloads the latest skill files and writes them into `.agents/skills/cap-operator/` in your project. Running the command again cleanly replaces the skill (stale files are pruned, unrelated skills under `.agents/` are left untouched).
 
 **Making the skill available in Claude Code**
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,30 @@ npx cap-op-plugin convert-to-configurable-template-chart --with-runtime-yaml <pr
 ```
 ![](.images/cap-op-plugin-convert-to-configurable-templates.gif)
 
+## Adding CAP Operator Agent Skill
+
+CAP Operator ships an [agent skill](https://github.com/SAP/cap-operator/tree/main/.agents/skills/cap-operator) that teaches AI coding assistants (such as Claude Code) how to manage CAP Operator resources on Kubernetes. You can add this skill to your project's `.agents/skills/cap-operator` folder using the plugin:
+
+```sh
+npx cap-op-plugin add-cap-operator-skill
+```
+
+This downloads the skill files from the **latest release** of CAP Operator and writes them into `.agents/skills/cap-operator/` in your project. Running the command again on a newer release cleanly replaces the skill files (orphaned files removed upstream are pruned), while leaving any other skills you keep under `.agents/` untouched.
+
+**Options**
+
+* `--version <release-version>` — Download the skill from a specific CAP Operator release instead of the latest:
+
+    ```sh
+    npx cap-op-plugin add-cap-operator-skill --version v0.33.0
+    ```
+
+* `--branch <branch-name>` — Download the skill directly from a branch (useful for testing unreleased changes):
+
+    ```sh
+    npx cap-op-plugin add-cap-operator-skill --branch main
+    ```
+
 ## Example
 
 As a reference, check out the [CAP Operator Helm chart](https://github.com/cap-js/incidents-app/tree/cap-operator-plugin/chart) in the sample incident app. Also, take a look at the corresponding [runtime-values.yaml](https://github.com/cap-js/incidents-app/blob/cap-operator-plugin/chart/runtime-values.yaml) file.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ npx cap-op-plugin add-cap-operator-skill
 
 This downloads the latest skill files and writes them into `.agents/skills/cap-operator/` in your project. Running the command again cleanly replaces the skill (stale files are pruned, unrelated skills under `.agents/` are left untouched).
 
+> **Note:** This command requires `tar` to be available on your system. On Windows, you may need to follow the [CAP troubleshooting guide for tar issues](https://cap.cloud.sap/docs/get-started/get-help#how-to-fix-tar-error-is-not-recoverable-exiting-now).
+
 **Making the skill available in Claude Code**
 
 Some AI tools, including Claude Code, may not automatically detect skills placed in a project's `.agents/` folder. If the skill is not picked up automatically, paste the following prompt into Claude Code to register it globally:

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -319,7 +319,7 @@ function httpGet(url, redirectCount = 0) {
 }
 
 async function addCapOperatorSkill() {
-    const SKILL_URL = 'https://sap.github.io/cap-operator/agents.tar.gz'
+    const SKILL_URL = 'https://sap.github.io/cap-operator/agentskills.tar.gz'
     const AGENTS_FOLDER = '.agents'
     const skillDest = cds.utils.path.join(cds.root, AGENTS_FOLDER)
 

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -307,11 +307,18 @@ function updateCdsConfigEnv(runtimeValuesYaml, workloadKey, workloadDefintion, c
         runtimeValuesYaml['workloads'][workloadKey][workloadDefintion]['env'].push({ name: 'CDS_CONFIG', value: cdsConfigHana })
 }
 
-function httpsGetJson(url) {
+const MAX_REDIRECTS = 10
+
+function httpsGetJson(url, redirectCount = 0) {
     return new Promise((resolve, reject) => {
         const req = https.get(url, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
             if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-                resolve(httpsGetJson(res.headers.location))
+                res.resume()
+                if (redirectCount >= MAX_REDIRECTS) {
+                    reject(new Error(`Too many redirects for ${url}`))
+                    return
+                }
+                resolve(httpsGetJson(res.headers.location, redirectCount + 1))
                 return
             }
             if (res.statusCode !== 200) {
@@ -321,7 +328,13 @@ function httpsGetJson(url) {
             }
             const chunks = []
             res.on('data', chunk => chunks.push(chunk))
-            res.on('end', () => resolve(JSON.parse(Buffer.concat(chunks).toString())))
+            res.on('end', () => {
+                try {
+                    resolve(JSON.parse(Buffer.concat(chunks).toString()))
+                } catch (e) {
+                    reject(new Error(`Failed to parse JSON response from ${url}: ${e.message}`))
+                }
+            })
         })
         req.on('error', reject)
     })
@@ -329,10 +342,15 @@ function httpsGetJson(url) {
 
 function streamTarball(url, onEntry) {
     return new Promise((resolve, reject) => {
+        let redirectCount = 0
         const follow = (target) => {
             https.get(target, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
                 if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
                     res.resume()
+                    if (++redirectCount > MAX_REDIRECTS) {
+                        reject(new Error(`Too many redirects downloading tarball`))
+                        return
+                    }
                     follow(res.headers.location)
                     return
                 }
@@ -341,7 +359,6 @@ function streamTarball(url, onEntry) {
                     reject(new Error(`HTTP ${res.statusCode} downloading tarball`))
                     return
                 }
-                const entries = []
                 let buf = Buffer.alloc(0)
 
                 const gunzip = zlib.createGunzip()
@@ -366,14 +383,14 @@ function streamTarball(url, onEntry) {
                             // strip leading top-level directory (e.g. "cap-operator-v0.33.0/")
                             const pathInTar = nameRaw.replace(/^[^/]+\//, '')
                             const content = buf.slice(512, 512 + size)
-                            entries.push(onEntry(pathInTar, content))
+                            onEntry(pathInTar, content)
                         }
 
                         buf = buf.slice(total)
                     }
                 })
 
-                gunzip.on('end', () => resolve(Promise.all(entries)))
+                gunzip.on('end', () => resolve())
                 res.pipe(gunzip)
             }).on('error', reject)
         }
@@ -415,7 +432,10 @@ async function addCapOperatorSkill({ branch, version } = {}) {
     }
 
     for (const { path: p, content } of agentFiles) {
-        await cds.utils.write(content).to(cds.utils.path.join(cds.root, p))
+        const abs = cds.utils.path.resolve(cds.root, p)
+        if (!abs.startsWith(cds.utils.path.resolve(cds.root) + cds.utils.path.sep))
+            throw new Error(`Unsafe path in tarball: ${p}`)
+        await cds.utils.write(content).to(abs)
     }
 
     console.log(`Added CAP Operator agent skills (${ref}) to '${AGENTS_FOLDER}'.`)

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -331,7 +331,7 @@ async function addCapOperatorSkill() {
     if (cds.utils.exists(capOpSkillDir)) await cds.utils.rimraf(capOpSkillDir)
 
     await cds.utils.fs.promises.mkdir(skillDest, { recursive: true })
-    await cds.utils.tar.extract(response).to(skillDest)
+    await cds.utils.tar.xzf(response).to(skillDest)
 
     console.log(`Added CAP Operator agent skills to '${AGENTS_FOLDER}'.`)
 }

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -320,19 +320,15 @@ function httpGet(url, redirectCount = 0) {
 
 async function addCapOperatorSkill() {
     const SKILL_URL = 'https://sap.github.io/cap-operator/agentskills.tar.gz'
-    const AGENTS_FOLDER = '.agents'
-    const skillDest = cds.utils.path.join(cds.root, AGENTS_FOLDER)
-
-    const response = await httpGet(SKILL_URL)
 
     // Wipe existing cap-operator skill dir so removed files are pruned on re-run
-    const capOpSkillDir = cds.utils.path.join(skillDest, 'skills', 'cap-operator')
+    const capOpSkillDir = cds.utils.path.join(cds.root, '.agents', 'skills', 'cap-operator')
     if (cds.utils.exists(capOpSkillDir)) await cds.utils.rimraf(capOpSkillDir)
 
-    await cds.utils.fs.promises.mkdir(skillDest, { recursive: true })
-    await cds.utils.tar.xzf(response).to(skillDest)
+    const response = await httpGet(SKILL_URL)
+    await cds.utils.tar.xzf(response).to(cds.root)
 
-    console.log(`Added CAP Operator agent skills to '${AGENTS_FOLDER}'.`)
+    console.log(`Added CAP Operator agent skills to '.agents'.`)
 }
 
 function getAppDetails() {

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -10,8 +10,6 @@ const cds = require('@sap/cds-dk')
 const yaml = require('@sap/cds-foss').yaml
 const Mustache = require('mustache')
 const { spawn } = require('child_process')
-const https = require('https')
-const zlib = require('zlib')
 
 const {
     ask,
@@ -26,7 +24,7 @@ const {
     getHelperTpl
 } = require('../lib/util')
 
-const SUPPORTED = { 'generate-runtime-values': ['--with-input-yaml'], 'convert-to-configurable-template-chart': ['--with-runtime-yaml'], 'add-cap-operator-skill': ['--branch', '--version'] }
+const SUPPORTED = { 'generate-runtime-values': ['--with-input-yaml'], 'convert-to-configurable-template-chart': ['--with-runtime-yaml'], 'add-cap-operator-skill': [] }
 
 async function capOperatorPlugin(cmd, option, optionValue) {
     try {
@@ -35,9 +33,7 @@ async function capOperatorPlugin(cmd, option, optionValue) {
         if (option && !SUPPORTED[cmd].includes(option)) return _usage(`Invalid option ${option}.`)
 
         if (cmd === 'add-cap-operator-skill') {
-            if (option === '--branch' && !optionValue) return _usage(`Branch name is missing.`)
-            if (option === '--version' && !optionValue) return _usage(`Version is missing.`)
-            await addCapOperatorSkill({ branch: option === '--branch' ? optionValue : undefined, version: option === '--version' ? optionValue : undefined })
+            await addCapOperatorSkill()
             return
         }
 
@@ -89,7 +85,7 @@ COMMANDS
 
     convert-to-configurable-template-chart [--with-runtime-yaml <runtime-yaml-path>]  Convert existing chart to configurable template chart
 
-    add-cap-operator-skill [--branch <branch-name> | --version <release-version>]   Add the CAP Operator agent skill to the .agents/skills/cap-operator folder
+    add-cap-operator-skill   Add the latest CAP Operator agent skill to the .agents/skills/cap-operator folder
 
 EXAMPLES
 
@@ -100,8 +96,6 @@ EXAMPLES
     cap-op-plugin convert-to-configurable-template-chart --with-runtime-yaml /path/to/runtime.yaml
 
     cap-op-plugin add-cap-operator-skill
-    cap-op-plugin add-cap-operator-skill --branch main
-    cap-op-plugin add-cap-operator-skill --version v0.33.0
 `
     )
 }
@@ -307,146 +301,39 @@ function updateCdsConfigEnv(runtimeValuesYaml, workloadKey, workloadDefintion, c
         runtimeValuesYaml['workloads'][workloadKey][workloadDefintion]['env'].push({ name: 'CDS_CONFIG', value: cdsConfigHana })
 }
 
-const MAX_REDIRECTS = 10
-
-function httpsGetJson(url, redirectCount = 0) {
+function httpGet(url, redirectCount = 0) {
     return new Promise((resolve, reject) => {
-        const req = https.get(url, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
+        const mod = url.startsWith('https') ? require('https') : require('http')
+        mod.get(url, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
             if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
                 res.resume()
-                if (redirectCount >= MAX_REDIRECTS) {
-                    reject(new Error(`Too many redirects for ${url}`))
-                    return
-                }
-                resolve(httpsGetJson(res.headers.location, redirectCount + 1))
-                return
-            }
-            if (res.statusCode !== 200) {
+                if (redirectCount >= 10) return reject(new Error('Too many redirects downloading skill tarball'))
+                resolve(httpGet(res.headers.location, redirectCount + 1))
+            } else if (res.statusCode !== 200) {
                 res.resume()
-                reject(new Error(`HTTP ${res.statusCode} for ${url}`))
-                return
+                reject(new Error(`Failed to download skill: HTTP ${res.statusCode}`))
+            } else {
+                resolve(res)
             }
-            const chunks = []
-            res.on('data', chunk => chunks.push(chunk))
-            res.on('end', () => {
-                try {
-                    resolve(JSON.parse(Buffer.concat(chunks).toString()))
-                } catch (e) {
-                    reject(new Error(`Failed to parse JSON response from ${url}: ${e.message}`))
-                }
-            })
-        })
-        req.on('error', reject)
+        }).on('error', reject)
     })
 }
 
-function streamTarball(url, onEntry) {
-    return new Promise((resolve, reject) => {
-        let redirectCount = 0
-        const follow = (target) => {
-            https.get(target, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
-                if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-                    res.resume()
-                    if (++redirectCount > MAX_REDIRECTS) {
-                        reject(new Error(`Too many redirects downloading tarball`))
-                        return
-                    }
-                    follow(res.headers.location)
-                    return
-                }
-                if (res.statusCode !== 200) {
-                    res.resume()
-                    reject(new Error(`HTTP ${res.statusCode} downloading tarball`))
-                    return
-                }
-                let buf = Buffer.alloc(0)
-
-                const gunzip = zlib.createGunzip()
-                gunzip.on('error', reject)
-
-                // Minimal tar parser: each 512-byte header block followed by content blocks
-                gunzip.on('data', chunk => {
-                    buf = Buffer.concat([buf, chunk])
-                    while (buf.length >= 512) {
-                        const nameRaw = buf.slice(0, 100).toString('utf8').replace(/\0/g, '')
-                        if (!nameRaw) { buf = buf.slice(512); continue }
-
-                        const sizeOctal = buf.slice(124, 136).toString('utf8').replace(/\0/g, '').trim()
-                        const size = parseInt(sizeOctal, 8) || 0
-                        const typeFlag = buf.slice(156, 157).toString('utf8').replace(/\0/g, '')
-                        const blocks = Math.ceil(size / 512)
-                        const total = 512 + blocks * 512
-
-                        if (buf.length < total) break
-
-                        if (typeFlag === '0' || typeFlag === '') {
-                            // strip leading top-level directory (e.g. "cap-operator-v0.33.0/")
-                            const pathInTar = nameRaw.replace(/^[^/]+\//, '')
-                            const content = buf.slice(512, 512 + size)
-                            onEntry(pathInTar, content)
-                        }
-
-                        buf = buf.slice(total)
-                    }
-                })
-
-                gunzip.on('end', () => resolve())
-                res.pipe(gunzip)
-            }).on('error', reject)
-        }
-        follow(url)
-    })
-}
-
-async function addCapOperatorSkill({ branch, version } = {}) {
-    const REPO = 'SAP/cap-operator'
+async function addCapOperatorSkill() {
+    const SKILL_URL = 'https://sap.github.io/cap-operator/agent.tar.gz'
     const AGENTS_FOLDER = '.agents'
+    const skillDest = cds.utils.path.join(cds.root, AGENTS_FOLDER)
 
-    let ref, tarballUrl
-    if (branch) {
-        ref = branch
-        tarballUrl = `https://github.com/${REPO}/archive/refs/heads/${branch}.tar.gz`
-    } else {
-        const tag = version ?? (await httpsGetJson(`https://api.github.com/repos/${REPO}/releases/latest`)).tag_name
-        ref = tag
-        tarballUrl = `https://github.com/${REPO}/archive/refs/tags/${tag}.tar.gz`
-    }
+    const response = await httpGet(SKILL_URL)
 
-    const agentFiles = []
-    try {
-        await streamTarball(tarballUrl, (pathInTar, content) => {
-            if (pathInTar.startsWith(`${AGENTS_FOLDER}/`))
-                agentFiles.push({ path: pathInTar, content: Buffer.from(content) })
-        })
-    } catch (e) {
-        if (e.message.includes('HTTP 404'))
-            throw new Error(branch
-                ? `Branch '${branch}' not found in ${REPO}.`
-                : `Release '${ref}' not found in ${REPO}.`)
-        throw e
-    }
+    // Wipe existing cap-operator skill dir so removed files are pruned on re-run
+    const capOpSkillDir = cds.utils.path.join(skillDest, 'skills', 'cap-operator')
+    if (cds.utils.exists(capOpSkillDir)) await cds.utils.rimraf(capOpSkillDir)
 
-    if (!agentFiles.length)
-        throw new Error(`No .agents folder found in cap-operator ${ref}.`)
+    await cds.utils.fs.promises.mkdir(skillDest, { recursive: true })
+    await cds.utils.tar.extract(response).to(skillDest)
 
-    const skillDirs = new Set()
-    for (const { path: p } of agentFiles) {
-        const match = p.match(/^\.agents\/skills\/[^/]+/)
-        if (match) skillDirs.add(match[0])
-    }
-    for (const dir of skillDirs) {
-        const abs = cds.utils.path.join(cds.root, dir)
-        if (cds.utils.exists(abs)) await cds.utils.rimraf(abs)
-    }
-
-    for (const { path: p, content } of agentFiles) {
-        const abs = cds.utils.path.resolve(cds.root, p)
-        if (!abs.startsWith(cds.utils.path.resolve(cds.root) + cds.utils.path.sep))
-            throw new Error(`Unsafe path in tarball: ${p}`)
-        await cds.utils.write(content).to(abs)
-    }
-
-    console.log(`Added CAP Operator agent skills (${ref}) to '${AGENTS_FOLDER}'.`)
+    console.log(`Added CAP Operator agent skills to '${AGENTS_FOLDER}'.`)
 }
 
 function getAppDetails() {

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -320,7 +320,7 @@ function httpGet(url, redirectCount = 0) {
 }
 
 async function addCapOperatorSkill() {
-    const SKILL_URL = 'https://sap.github.io/cap-operator/agent.tar.gz'
+    const SKILL_URL = 'https://sap.github.io/cap-operator/agents.tar.gz'
     const AGENTS_FOLDER = '.agents'
     const skillDest = cds.utils.path.join(cds.root, AGENTS_FOLDER)
 

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -303,8 +303,7 @@ function updateCdsConfigEnv(runtimeValuesYaml, workloadKey, workloadDefintion, c
 
 function httpGet(url, redirectCount = 0) {
     return new Promise((resolve, reject) => {
-        const mod = url.startsWith('https') ? require('https') : require('http')
-        mod.get(url, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
+        require('https').get(url, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
             if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
                 res.resume()
                 if (redirectCount >= 10) return reject(new Error('Too many redirects downloading skill tarball'))

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -10,6 +10,8 @@ const cds = require('@sap/cds-dk')
 const yaml = require('@sap/cds-foss').yaml
 const Mustache = require('mustache')
 const { spawn } = require('child_process')
+const https = require('https')
+const zlib = require('zlib')
 
 const {
     ask,
@@ -24,32 +26,39 @@ const {
     getHelperTpl
 } = require('../lib/util')
 
-const SUPPORTED = { 'generate-runtime-values': ['--with-input-yaml'], 'convert-to-configurable-template-chart': ['--with-runtime-yaml'] }
+const SUPPORTED = { 'generate-runtime-values': ['--with-input-yaml'], 'convert-to-configurable-template-chart': ['--with-runtime-yaml'], 'add-cap-operator-skill': ['--branch', '--version'] }
 
-async function capOperatorPlugin(cmd, option, yamlPath) {
+async function capOperatorPlugin(cmd, option, optionValue) {
     try {
         if (!cmd) return _usage()
         if (!Object.keys(SUPPORTED).includes(cmd)) return _usage(`Unknown command ${cmd}.`)
         if (option && !SUPPORTED[cmd].includes(option)) return _usage(`Invalid option ${option}.`)
 
+        if (cmd === 'add-cap-operator-skill') {
+            if (option === '--branch' && !optionValue) return _usage(`Branch name is missing.`)
+            if (option === '--version' && !optionValue) return _usage(`Version is missing.`)
+            await addCapOperatorSkill({ branch: option === '--branch' ? optionValue : undefined, version: option === '--version' ? optionValue : undefined })
+            return
+        }
+
         if (cmd === 'generate-runtime-values') {
-            if (option === '--with-input-yaml' && !yamlPath)
+            if (option === '--with-input-yaml' && !optionValue)
                 return _usage(`Input yaml path is missing.`)
 
-            if (option === '--with-input-yaml' && yamlPath && !cds.utils.exists(cds.utils.path.join(cds.root, yamlPath)))
-                return _usage(`Input yaml path ${yamlPath} does not exist.`)
+            if (option === '--with-input-yaml' && optionValue && !cds.utils.exists(cds.utils.path.join(cds.root, optionValue)))
+                return _usage(`Input yaml path ${optionValue} does not exist.`)
 
-            await generateRuntimeValues(option, yamlPath)
+            await generateRuntimeValues(option, optionValue)
         }
 
         if (cmd === 'convert-to-configurable-template-chart') {
-            if (option === '--with-runtime-yaml' && !yamlPath)
+            if (option === '--with-runtime-yaml' && !optionValue)
                 return _usage(`Input runtime yaml path is missing.`)
 
-            if (option === '--with-runtime-yaml' && yamlPath && !cds.utils.exists(cds.utils.path.join(cds.root, yamlPath)))
-                return _usage(`Input runtime yaml path ${yamlPath} does not exist.`)
+            if (option === '--with-runtime-yaml' && optionValue && !cds.utils.exists(cds.utils.path.join(cds.root, optionValue)))
+                return _usage(`Input runtime yaml path ${optionValue} does not exist.`)
 
-            await convertToconfigurableTemplateChart(option, yamlPath)
+            await convertToconfigurableTemplateChart(option, optionValue)
         }
     } catch (e) {
         if (isCli) {
@@ -80,6 +89,8 @@ COMMANDS
 
     convert-to-configurable-template-chart [--with-runtime-yaml <runtime-yaml-path>]  Convert existing chart to configurable template chart
 
+    add-cap-operator-skill [--branch <branch-name> | --version <release-version>]   Add the CAP Operator agent skill to the .agents/skills/cap-operator folder
+
 EXAMPLES
 
     cap-op-plugin generate-runtime-values
@@ -87,6 +98,10 @@ EXAMPLES
 
     cap-op-plugin convert-to-configurable-template-chart
     cap-op-plugin convert-to-configurable-template-chart --with-runtime-yaml /path/to/runtime.yaml
+
+    cap-op-plugin add-cap-operator-skill
+    cap-op-plugin add-cap-operator-skill --branch main
+    cap-op-plugin add-cap-operator-skill --version v0.33.0
 `
     )
 }
@@ -292,6 +307,120 @@ function updateCdsConfigEnv(runtimeValuesYaml, workloadKey, workloadDefintion, c
         runtimeValuesYaml['workloads'][workloadKey][workloadDefintion]['env'].push({ name: 'CDS_CONFIG', value: cdsConfigHana })
 }
 
+function httpsGetJson(url) {
+    return new Promise((resolve, reject) => {
+        const req = https.get(url, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                resolve(httpsGetJson(res.headers.location))
+                return
+            }
+            if (res.statusCode !== 200) {
+                res.resume()
+                reject(new Error(`HTTP ${res.statusCode} for ${url}`))
+                return
+            }
+            const chunks = []
+            res.on('data', chunk => chunks.push(chunk))
+            res.on('end', () => resolve(JSON.parse(Buffer.concat(chunks).toString())))
+        })
+        req.on('error', reject)
+    })
+}
+
+function streamTarball(url, onEntry) {
+    return new Promise((resolve, reject) => {
+        const follow = (target) => {
+            https.get(target, { headers: { 'User-Agent': 'cap-operator-plugin' } }, res => {
+                if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                    res.resume()
+                    follow(res.headers.location)
+                    return
+                }
+                if (res.statusCode !== 200) {
+                    res.resume()
+                    reject(new Error(`HTTP ${res.statusCode} downloading tarball`))
+                    return
+                }
+                const entries = []
+                let buf = Buffer.alloc(0)
+
+                const gunzip = zlib.createGunzip()
+                gunzip.on('error', reject)
+
+                // Minimal tar parser: each 512-byte header block followed by content blocks
+                gunzip.on('data', chunk => {
+                    buf = Buffer.concat([buf, chunk])
+                    while (buf.length >= 512) {
+                        const nameRaw = buf.slice(0, 100).toString('utf8').replace(/\0/g, '')
+                        if (!nameRaw) { buf = buf.slice(512); continue }
+
+                        const sizeOctal = buf.slice(124, 136).toString('utf8').replace(/\0/g, '').trim()
+                        const size = parseInt(sizeOctal, 8) || 0
+                        const typeFlag = buf.slice(156, 157).toString('utf8').replace(/\0/g, '')
+                        const blocks = Math.ceil(size / 512)
+                        const total = 512 + blocks * 512
+
+                        if (buf.length < total) break
+
+                        if (typeFlag === '0' || typeFlag === '') {
+                            // strip leading top-level directory (e.g. "cap-operator-v0.33.0/")
+                            const pathInTar = nameRaw.replace(/^[^/]+\//, '')
+                            const content = buf.slice(512, 512 + size)
+                            entries.push(onEntry(pathInTar, content))
+                        }
+
+                        buf = buf.slice(total)
+                    }
+                })
+
+                gunzip.on('end', () => resolve(Promise.all(entries)))
+                res.pipe(gunzip)
+            }).on('error', reject)
+        }
+        follow(url)
+    })
+}
+
+async function addCapOperatorSkill({ branch, version } = {}) {
+    const REPO = 'SAP/cap-operator'
+    const AGENTS_FOLDER = '.agents'
+
+    let ref, tarballUrl
+    if (branch) {
+        ref = branch
+        tarballUrl = `https://github.com/${REPO}/archive/refs/heads/${branch}.tar.gz`
+    } else {
+        const tag = version ?? (await httpsGetJson(`https://api.github.com/repos/${REPO}/releases/latest`)).tag_name
+        ref = tag
+        tarballUrl = `https://github.com/${REPO}/archive/refs/tags/${tag}.tar.gz`
+    }
+
+    const agentFiles = []
+    await streamTarball(tarballUrl, (pathInTar, content) => {
+        if (pathInTar.startsWith(`${AGENTS_FOLDER}/`))
+            agentFiles.push({ path: pathInTar, content: Buffer.from(content) })
+    })
+
+    if (!agentFiles.length)
+        throw new Error(`No .agents folder found in cap-operator ${ref}.`)
+
+    const skillDirs = new Set()
+    for (const { path: p } of agentFiles) {
+        const match = p.match(/^\.agents\/skills\/[^/]+/)
+        if (match) skillDirs.add(match[0])
+    }
+    for (const dir of skillDirs) {
+        const abs = cds.utils.path.join(cds.root, dir)
+        if (cds.utils.exists(abs)) await cds.utils.rimraf(abs)
+    }
+
+    for (const { path: p, content } of agentFiles) {
+        await cds.utils.write(content).to(cds.utils.path.join(cds.root, p))
+    }
+
+    console.log(`Added CAP Operator agent skills (${ref}) to '${AGENTS_FOLDER}'.`)
+}
+
 function getAppDetails() {
     const { name, description } = JSON.parse(cds.utils.fs.readFileSync(cds.utils.path.join(cds.root, 'package.json')))
     const segments = (name ?? this.appName).trim().replace(/@/g, '').split('/').map(encodeURIComponent)
@@ -323,8 +452,8 @@ async function getShootDomain() {
 }
 
 if (isCli) {
-    const [, , cmd, option, yamlPath] = process.argv;
-    (async () => await capOperatorPlugin(cmd, option, yamlPath ?? undefined))()
+    const [, , cmd, option, optionValue] = process.argv;
+    (async () => await capOperatorPlugin(cmd, option, optionValue ?? undefined))()
 }
 
 module.exports = { capOperatorPlugin }

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -413,10 +413,18 @@ async function addCapOperatorSkill({ branch, version } = {}) {
     }
 
     const agentFiles = []
-    await streamTarball(tarballUrl, (pathInTar, content) => {
-        if (pathInTar.startsWith(`${AGENTS_FOLDER}/`))
-            agentFiles.push({ path: pathInTar, content: Buffer.from(content) })
-    })
+    try {
+        await streamTarball(tarballUrl, (pathInTar, content) => {
+            if (pathInTar.startsWith(`${AGENTS_FOLDER}/`))
+                agentFiles.push({ path: pathInTar, content: Buffer.from(content) })
+        })
+    } catch (e) {
+        if (e.message.includes('HTTP 404'))
+            throw new Error(branch
+                ? `Branch '${branch}' not found in ${REPO}.`
+                : `Release '${ref}' not found in ${REPO}.`)
+        throw e
+    }
 
     if (!agentFiles.length)
         throw new Error(`No .agents folder found in cap-operator ${ref}.`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cap-operator-plugin",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Add/Build Plugin for CAP Operator",
   "homepage": "https://github.com/cap-js/cap-operator-plugin/blob/main/README.md",
   "repository": {

--- a/test/cap-op-plugin.test.js
+++ b/test/cap-op-plugin.test.js
@@ -3,10 +3,6 @@ const { join } = require('node:path')
 const { execSync } = require('node:child_process')
 const { expect } = require('chai')
 const sinon = require('sinon')
-const https = require('https')
-const zlib = require('zlib')
-const { EventEmitter } = require('node:events')
-const { Readable } = require('node:stream')
 
 const TempUtil = require('./tempUtil')
 const tempUtil = new TempUtil(__filename, { local: true })
@@ -68,7 +64,7 @@ COMMANDS
 
     convert-to-configurable-template-chart [--with-runtime-yaml <runtime-yaml-path>]  Convert existing chart to configurable template chart
 
-    add-cap-operator-skill [--branch <branch-name> | --version <release-version>]   Add the CAP Operator agent skill to the .agents/skills/cap-operator folder
+    add-cap-operator-skill   Add the latest CAP Operator agent skill to the .agents/skills/cap-operator folder
 
 EXAMPLES
 
@@ -79,8 +75,6 @@ EXAMPLES
     cap-op-plugin convert-to-configurable-template-chart --with-runtime-yaml /path/to/runtime.yaml
 
     cap-op-plugin add-cap-operator-skill
-    cap-op-plugin add-cap-operator-skill --branch main
-    cap-op-plugin add-cap-operator-skill --version v0.33.0
 `)
     })
 
@@ -291,215 +285,49 @@ EXAMPLES
     //------------------------------------------------
 
     describe('add-cap-operator-skill', () => {
-        function makeTarGz(files) {
-            const blocks = []
-            for (const { path: filePath, content } of files) {
-                const contentBuf = Buffer.isBuffer(content) ? content : Buffer.from(content)
-                const header = Buffer.alloc(512)
-                header.write(filePath, 0, 100, 'utf8')
-                header.write('0000644\0', 100, 8, 'utf8')
-                const sizeOctal = contentBuf.length.toString(8).padStart(11, '0') + ' '
-                header.write(sizeOctal, 124, 12, 'utf8')
-                header.write('0', 156, 1, 'utf8')
-                header.fill(32, 148, 156)
-                let sum = 0
-                for (let i = 0; i < 512; i++) sum += header[i]
-                header.write(sum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'utf8')
-                blocks.push(header)
-                const padded = Buffer.alloc(Math.ceil(contentBuf.length / 512) * 512)
-                contentBuf.copy(padded)
-                blocks.push(padded)
-            }
-            blocks.push(Buffer.alloc(1024))
-            return zlib.gzipSync(Buffer.concat(blocks))
-        }
-
-        function stubHttpsWithTarball(tag, tarGzBuf) {
-            sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
-                const req = new EventEmitter()
-                setImmediate(() => {
-                    if (url.includes('releases/latest')) {
-                        const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                        callback(res)
-                        res.push(JSON.stringify({ tag_name: tag }))
-                        res.push(null)
-                    } else {
-                        const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                        callback(res)
-                        res.push(tarGzBuf)
-                        res.push(null)
-                    }
-                })
-                return req
-            })
-        }
-
         beforeEach(() => { cds.root = bookshop })
 
         afterEach(() => {
-            sinon.restore()
             if (cds.utils.exists(join(bookshop, '.agents')))
                 execSync('rm -rf .agents', { cwd: bookshop })
         })
 
-        it('extracts .agents folder from tarball', async () => {
-            stubHttpsWithTarball('v0.33.0', makeTarGz([
-                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
-                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/deploy.md', content: '# deploy' },
-                { path: 'cap-operator-v0.33.0/README.md', content: 'readme' }
-            ]))
-
+        it('downloads and extracts skill files from live URL', async () => {
             await capOperatorPlugin('add-cap-operator-skill')
 
             expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.be.ok
-            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.be.ok
-            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL')
-            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.equal('# deploy')
-            expect(cds.utils.exists(join(bookshop, '.agents/README.md'))).to.not.be.ok
+            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references'))).to.be.ok
         })
 
-        it('overwrites existing files', async () => {
+        it('overwrites existing files on re-run', async () => {
             await cds.utils.write('old content').to(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))
-            stubHttpsWithTarball('v0.33.0', makeTarGz([
-                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: 'new content' }
-            ]))
 
             await capOperatorPlugin('add-cap-operator-skill')
 
-            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('new content')
+            const content = await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))
+            expect(content).to.not.equal('old content')
         })
 
-        it('prunes files removed upstream on re-run', async () => {
-            stubHttpsWithTarball('v0.33.0', makeTarGz([
-                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
-                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/old.md', content: '# old' }
-            ]))
-            await capOperatorPlugin('add-cap-operator-skill')
-            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.be.ok
-            sinon.restore()
+        it('prunes stale files on re-run', async () => {
+            await cds.utils.write('stale').to(join(bookshop, '.agents/skills/cap-operator/stale.md'))
 
+            await capOperatorPlugin('add-cap-operator-skill')
+
+            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/stale.md'))).to.not.be.ok
+        })
+
+        it('preserves unrelated skills', async () => {
             await cds.utils.write('mine').to(join(bookshop, '.agents/skills/my-own/SKILL.md'))
 
-            stubHttpsWithTarball('v0.34.0', makeTarGz([
-                { path: 'cap-operator-v0.34.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v2' }
-            ]))
             await capOperatorPlugin('add-cap-operator-skill')
 
-            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v2')
-            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.not.be.ok
             expect(await cds.utils.read(join(bookshop, '.agents/skills/my-own/SKILL.md'))).to.equal('mine')
         })
 
-        it('throws when release fetch fails', async () => {
-            sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
-                const req = new EventEmitter()
-                setImmediate(() => {
-                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
-                    callback(res)
-                    res.push(null)
-                })
-                return req
-            })
-
+        it('rejects unknown option', async () => {
             let error
-            try { await capOperatorPlugin('add-cap-operator-skill') } catch (e) { error = e }
-            expect(error?.message).to.include('HTTP 404')
-        })
-
-        it('--branch throws descriptive error when branch does not exist', async () => {
-            sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
-                const req = new EventEmitter()
-                setImmediate(() => {
-                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
-                    callback(res)
-                    res.push(null)
-                })
-                return req
-            })
-
-            let error
-            try { await capOperatorPlugin('add-cap-operator-skill', '--branch', 'no-such-branch') } catch (e) { error = e }
-            expect(error?.message).to.equal(`Branch 'no-such-branch' not found in SAP/cap-operator.`)
-        })
-
-        it('--version throws descriptive error when release does not exist', async () => {
-            sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
-                const req = new EventEmitter()
-                setImmediate(() => {
-                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
-                    callback(res)
-                    res.push(null)
-                })
-                return req
-            })
-
-            let error
-            try { await capOperatorPlugin('add-cap-operator-skill', '--version', 'v0.0.0') } catch (e) { error = e }
-            expect(error?.message).to.equal(`Release 'v0.0.0' not found in SAP/cap-operator.`)
-        })
-
-        it('throws when tarball has no .agents folder', async () => {
-            stubHttpsWithTarball('v0.1.0', makeTarGz([
-                { path: 'cap-operator-v0.1.0/README.md', content: 'readme' }
-            ]))
-
-            let error
-            try { await capOperatorPlugin('add-cap-operator-skill') } catch (e) { error = e }
-            expect(error?.message).to.include('No .agents folder found in cap-operator v0.1.0')
-        })
-
-        it('--version downloads specific release tarball without API call', async () => {
-            let capturedUrl
-            sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
-                capturedUrl = url
-                const req = new EventEmitter()
-                setImmediate(() => {
-                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                    callback(res)
-                    res.push(makeTarGz([{ path: 'cap-operator-v0.30.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v0.30.0' }]))
-                    res.push(null)
-                })
-                return req
-            })
-
-            await capOperatorPlugin('add-cap-operator-skill', '--version', 'v0.30.0')
-
-            expect(capturedUrl).to.include('tags/v0.30.0')
-            expect(capturedUrl).to.not.include('releases/latest')
-            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v0.30.0')
-        })
-
-        it('--branch downloads branch tarball without API call', async () => {
-            let capturedUrl
-            sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
-                capturedUrl = url
-                const req = new EventEmitter()
-                setImmediate(() => {
-                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                    callback(res)
-                    res.push(makeTarGz([{ path: 'cap-operator-main/.agents/skills/cap-operator/SKILL.md', content: '# SKILL main' }]))
-                    res.push(null)
-                })
-                return req
-            })
-
-            await capOperatorPlugin('add-cap-operator-skill', '--branch', 'main')
-
-            expect(capturedUrl).to.include('heads/main')
-            expect(capturedUrl).to.not.include('releases/latest')
-            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL main')
-        })
-
-        it('--branch missing value shows usage error', async () => {
-            let error
-            try { await capOperatorPlugin('add-cap-operator-skill', '--branch', undefined) } catch (e) { error = e }
-            expect(error?.message).to.include('Branch name is missing.')
-        })
-
-        it('--version missing value shows usage error', async () => {
-            let error
-            try { await capOperatorPlugin('add-cap-operator-skill', '--version', undefined) } catch (e) { error = e }
-            expect(error?.message).to.include('Version is missing.')
+            try { await capOperatorPlugin('add-cap-operator-skill', '--unknown') } catch (e) { error = e }
+            expect(error?.message).to.include('Invalid option --unknown')
         })
     })
 })

--- a/test/cap-op-plugin.test.js
+++ b/test/cap-op-plugin.test.js
@@ -406,6 +406,38 @@ EXAMPLES
             expect(error?.message).to.include('HTTP 404')
         })
 
+        it('--branch throws descriptive error when branch does not exist', async () => {
+            sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
+                const req = new EventEmitter()
+                setImmediate(() => {
+                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
+                    callback(res)
+                    res.push(null)
+                })
+                return req
+            })
+
+            let error
+            try { await capOperatorPlugin('add-cap-operator-skill', '--branch', 'no-such-branch') } catch (e) { error = e }
+            expect(error?.message).to.equal(`Branch 'no-such-branch' not found in SAP/cap-operator.`)
+        })
+
+        it('--version throws descriptive error when release does not exist', async () => {
+            sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
+                const req = new EventEmitter()
+                setImmediate(() => {
+                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
+                    callback(res)
+                    res.push(null)
+                })
+                return req
+            })
+
+            let error
+            try { await capOperatorPlugin('add-cap-operator-skill', '--version', 'v0.0.0') } catch (e) { error = e }
+            expect(error?.message).to.equal(`Release 'v0.0.0' not found in SAP/cap-operator.`)
+        })
+
         it('throws when tarball has no .agents folder', async () => {
             stubHttpsWithTarball('v0.1.0', makeTarGz([
                 { path: 'cap-operator-v0.1.0/README.md', content: 'readme' }

--- a/test/cap-op-plugin.test.js
+++ b/test/cap-op-plugin.test.js
@@ -290,267 +290,184 @@ EXAMPLES
     // add-cap-operator-skill test cases
     //------------------------------------------------
 
-    function makeTarGz(files) {
-        // files: [{ path, content }] — builds a minimal .tar.gz in memory
-        const blocks = []
-        for (const { path: filePath, content } of files) {
-            const contentBuf = Buffer.isBuffer(content) ? content : Buffer.from(content)
-            const header = Buffer.alloc(512)
-            header.write(filePath, 0, 100, 'utf8')
-            header.write('0000644\0', 100, 8, 'utf8')  // mode
-            const sizeOctal = contentBuf.length.toString(8).padStart(11, '0') + ' '
-            header.write(sizeOctal, 124, 12, 'utf8')
-            header.write('0', 156, 1, 'utf8')  // type: regular file
-            // checksum
-            header.fill(32, 148, 156)
-            let sum = 0
-            for (let i = 0; i < 512; i++) sum += header[i]
-            header.write(sum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'utf8')
-
-            blocks.push(header)
-            const padded = Buffer.alloc(Math.ceil(contentBuf.length / 512) * 512)
-            contentBuf.copy(padded)
-            blocks.push(padded)
+    describe('add-cap-operator-skill', () => {
+        function makeTarGz(files) {
+            const blocks = []
+            for (const { path: filePath, content } of files) {
+                const contentBuf = Buffer.isBuffer(content) ? content : Buffer.from(content)
+                const header = Buffer.alloc(512)
+                header.write(filePath, 0, 100, 'utf8')
+                header.write('0000644\0', 100, 8, 'utf8')
+                const sizeOctal = contentBuf.length.toString(8).padStart(11, '0') + ' '
+                header.write(sizeOctal, 124, 12, 'utf8')
+                header.write('0', 156, 1, 'utf8')
+                header.fill(32, 148, 156)
+                let sum = 0
+                for (let i = 0; i < 512; i++) sum += header[i]
+                header.write(sum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'utf8')
+                blocks.push(header)
+                const padded = Buffer.alloc(Math.ceil(contentBuf.length / 512) * 512)
+                contentBuf.copy(padded)
+                blocks.push(padded)
+            }
+            blocks.push(Buffer.alloc(1024))
+            return zlib.gzipSync(Buffer.concat(blocks))
         }
-        blocks.push(Buffer.alloc(1024)) // EOF marker
-        return zlib.gzipSync(Buffer.concat(blocks))
-    }
 
-    function stubHttpsWithTarball(tag, tarGzBuf) {
-        sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
-            const req = new EventEmitter()
-            setImmediate(() => {
-                if (url.includes('releases/latest')) {
+        function stubHttpsWithTarball(tag, tarGzBuf) {
+            sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
+                const req = new EventEmitter()
+                setImmediate(() => {
+                    if (url.includes('releases/latest')) {
+                        const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                        callback(res)
+                        res.push(JSON.stringify({ tag_name: tag }))
+                        res.push(null)
+                    } else {
+                        const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                        callback(res)
+                        res.push(tarGzBuf)
+                        res.push(null)
+                    }
+                })
+                return req
+            })
+        }
+
+        beforeEach(() => { cds.root = bookshop })
+
+        afterEach(() => {
+            sinon.restore()
+            if (cds.utils.exists(join(bookshop, '.agents')))
+                execSync('rm -rf .agents', { cwd: bookshop })
+        })
+
+        it('extracts .agents folder from tarball', async () => {
+            stubHttpsWithTarball('v0.33.0', makeTarGz([
+                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
+                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/deploy.md', content: '# deploy' },
+                { path: 'cap-operator-v0.33.0/README.md', content: 'readme' }
+            ]))
+
+            await capOperatorPlugin('add-cap-operator-skill')
+
+            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.be.ok
+            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.be.ok
+            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL')
+            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.equal('# deploy')
+            expect(cds.utils.exists(join(bookshop, '.agents/README.md'))).to.not.be.ok
+        })
+
+        it('overwrites existing files', async () => {
+            await cds.utils.write('old content').to(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))
+            stubHttpsWithTarball('v0.33.0', makeTarGz([
+                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: 'new content' }
+            ]))
+
+            await capOperatorPlugin('add-cap-operator-skill')
+
+            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('new content')
+        })
+
+        it('prunes files removed upstream on re-run', async () => {
+            stubHttpsWithTarball('v0.33.0', makeTarGz([
+                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
+                { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/old.md', content: '# old' }
+            ]))
+            await capOperatorPlugin('add-cap-operator-skill')
+            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.be.ok
+            sinon.restore()
+
+            await cds.utils.write('mine').to(join(bookshop, '.agents/skills/my-own/SKILL.md'))
+
+            stubHttpsWithTarball('v0.34.0', makeTarGz([
+                { path: 'cap-operator-v0.34.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v2' }
+            ]))
+            await capOperatorPlugin('add-cap-operator-skill')
+
+            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v2')
+            expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.not.be.ok
+            expect(await cds.utils.read(join(bookshop, '.agents/skills/my-own/SKILL.md'))).to.equal('mine')
+        })
+
+        it('throws when release fetch fails', async () => {
+            sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
+                const req = new EventEmitter()
+                setImmediate(() => {
+                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
+                    callback(res)
+                    res.push(null)
+                })
+                return req
+            })
+
+            let error
+            try { await capOperatorPlugin('add-cap-operator-skill') } catch (e) { error = e }
+            expect(error?.message).to.include('HTTP 404')
+        })
+
+        it('throws when tarball has no .agents folder', async () => {
+            stubHttpsWithTarball('v0.1.0', makeTarGz([
+                { path: 'cap-operator-v0.1.0/README.md', content: 'readme' }
+            ]))
+
+            let error
+            try { await capOperatorPlugin('add-cap-operator-skill') } catch (e) { error = e }
+            expect(error?.message).to.include('No .agents folder found in cap-operator v0.1.0')
+        })
+
+        it('--version downloads specific release tarball without API call', async () => {
+            let capturedUrl
+            sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
+                capturedUrl = url
+                const req = new EventEmitter()
+                setImmediate(() => {
                     const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
                     callback(res)
-                    res.push(JSON.stringify({ tag_name: tag }))
+                    res.push(makeTarGz([{ path: 'cap-operator-v0.30.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v0.30.0' }]))
                     res.push(null)
-                } else {
-                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                    callback(res)
-                    res.push(tarGzBuf)
-                    res.push(null)
-                }
+                })
+                return req
             })
-            return req
-        })
-    }
 
-    function stubHttpsTarballOnly(tarGzBuf) {
-        sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
-            const req = new EventEmitter()
-            setImmediate(() => {
-                const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                callback(res)
-                res.push(tarGzBuf)
-                res.push(null)
-            })
-            return req
-        })
-    }
-
-    afterEach(() => {
-        if (cds.utils.exists(join(bookshop, '.agents')))
-            execSync('rm -rf .agents', { cwd: bookshop })
-    })
-
-    it('Add CAP Operator skill extracts .agents folder from tarball', async () => {
-        const tarGz = makeTarGz([
-            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
-            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/deploy.md', content: '# deploy' },
-            { path: 'cap-operator-v0.33.0/README.md', content: 'readme' }
-        ])
-        stubHttpsWithTarball('v0.33.0', tarGz)
-
-        cds.root = bookshop
-        try {
-            await capOperatorPlugin('add-cap-operator-skill')
-        } finally {
-            sinon.restore()
-        }
-
-        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.be.ok
-        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.be.ok
-        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL')
-        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.equal('# deploy')
-    })
-
-    it('Add CAP Operator skill overwrites existing files', async () => {
-        await cds.utils.write('old content').to(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))
-
-        const tarGz = makeTarGz([
-            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: 'new content' }
-        ])
-        stubHttpsWithTarball('v0.33.0', tarGz)
-
-        cds.root = bookshop
-        try {
-            await capOperatorPlugin('add-cap-operator-skill')
-        } finally {
-            sinon.restore()
-        }
-
-        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('new content')
-    })
-
-    it('Add CAP Operator skill prunes files removed upstream on re-run', async () => {
-        cds.root = bookshop
-
-        // First run: ships two reference files
-        const firstTar = makeTarGz([
-            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
-            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/old.md', content: '# old' }
-        ])
-        stubHttpsWithTarball('v0.33.0', firstTar)
-        try {
-            await capOperatorPlugin('add-cap-operator-skill')
-        } finally {
-            sinon.restore()
-        }
-        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.be.ok
-
-        // A user's own skill living alongside — must survive the re-run
-        await cds.utils.write('mine').to(join(bookshop, '.agents/skills/my-own/SKILL.md'))
-
-        // Second run: upstream dropped old.md
-        const secondTar = makeTarGz([
-            { path: 'cap-operator-v0.34.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v2' }
-        ])
-        stubHttpsWithTarball('v0.34.0', secondTar)
-        try {
-            await capOperatorPlugin('add-cap-operator-skill')
-        } finally {
-            sinon.restore()
-        }
-
-        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v2')
-        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.not.be.ok
-        // unrelated user skill is untouched
-        expect(await cds.utils.read(join(bookshop, '.agents/skills/my-own/SKILL.md'))).to.equal('mine')
-    })
-
-    it('Add CAP Operator skill throws when release fetch fails', async () => {
-        sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
-            const req = new EventEmitter()
-            setImmediate(() => {
-                const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
-                callback(res)
-                res.push(null)
-            })
-            return req
-        })
-
-        cds.root = bookshop
-        let error
-        try {
-            await capOperatorPlugin('add-cap-operator-skill')
-        } catch (e) {
-            error = e
-        } finally {
-            sinon.restore()
-        }
-
-        expect(error?.message).to.include('HTTP 404')
-    })
-
-    it('Add CAP Operator skill throws when tarball has no .agents folder', async () => {
-        const tarGz = makeTarGz([
-            { path: 'cap-operator-v0.1.0/README.md', content: 'readme' }
-        ])
-        stubHttpsWithTarball('v0.1.0', tarGz)
-
-        cds.root = bookshop
-        let error
-        try {
-            await capOperatorPlugin('add-cap-operator-skill')
-        } catch (e) {
-            error = e
-        } finally {
-            sinon.restore()
-        }
-
-        expect(error?.message).to.include('No .agents folder found in cap-operator v0.1.0')
-    })
-
-    it('Add CAP Operator skill --version downloads specific release tarball', async () => {
-        const tarGz = makeTarGz([
-            { path: 'cap-operator-v0.30.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v0.30.0' }
-        ])
-
-        let capturedUrl
-        sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
-            capturedUrl = url
-            const req = new EventEmitter()
-            setImmediate(() => {
-                const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                callback(res)
-                res.push(tarGz)
-                res.push(null)
-            })
-            return req
-        })
-
-        cds.root = bookshop
-        try {
             await capOperatorPlugin('add-cap-operator-skill', '--version', 'v0.30.0')
-        } finally {
-            sinon.restore()
-        }
 
-        expect(capturedUrl).to.include('tags/v0.30.0')
-        expect(capturedUrl).to.not.include('releases/latest')
-        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v0.30.0')
-    })
-
-    it('Add CAP Operator skill --branch downloads branch tarball without API call', async () => {
-        const tarGz = makeTarGz([
-            { path: 'cap-operator-main/.agents/skills/cap-operator/SKILL.md', content: '# SKILL main' }
-        ])
-
-        let capturedUrl
-        sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
-            capturedUrl = url
-            const req = new EventEmitter()
-            setImmediate(() => {
-                const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
-                callback(res)
-                res.push(tarGz)
-                res.push(null)
-            })
-            return req
+            expect(capturedUrl).to.include('tags/v0.30.0')
+            expect(capturedUrl).to.not.include('releases/latest')
+            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v0.30.0')
         })
 
-        cds.root = bookshop
-        try {
+        it('--branch downloads branch tarball without API call', async () => {
+            let capturedUrl
+            sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
+                capturedUrl = url
+                const req = new EventEmitter()
+                setImmediate(() => {
+                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                    callback(res)
+                    res.push(makeTarGz([{ path: 'cap-operator-main/.agents/skills/cap-operator/SKILL.md', content: '# SKILL main' }]))
+                    res.push(null)
+                })
+                return req
+            })
+
             await capOperatorPlugin('add-cap-operator-skill', '--branch', 'main')
-        } finally {
-            sinon.restore()
-        }
 
-        expect(capturedUrl).to.include('heads/main')
-        expect(capturedUrl).to.not.include('releases/latest')
-        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL main')
-    })
+            expect(capturedUrl).to.include('heads/main')
+            expect(capturedUrl).to.not.include('releases/latest')
+            expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL main')
+        })
 
-    it('Add CAP Operator skill --branch missing value shows usage error', async () => {
-        cds.root = bookshop
-        let error
-        try {
-            await capOperatorPlugin('add-cap-operator-skill', '--branch', undefined)
-        } catch (e) {
-            error = e
-        }
-        expect(error?.message).to.include('Branch name is missing.')
-    })
+        it('--branch missing value shows usage error', async () => {
+            let error
+            try { await capOperatorPlugin('add-cap-operator-skill', '--branch', undefined) } catch (e) { error = e }
+            expect(error?.message).to.include('Branch name is missing.')
+        })
 
-    it('Add CAP Operator skill --version missing value shows usage error', async () => {
-        cds.root = bookshop
-        let error
-        try {
-            await capOperatorPlugin('add-cap-operator-skill', '--version', undefined)
-        } catch (e) {
-            error = e
-        }
-        expect(error?.message).to.include('Version is missing.')
+        it('--version missing value shows usage error', async () => {
+            let error
+            try { await capOperatorPlugin('add-cap-operator-skill', '--version', undefined) } catch (e) { error = e }
+            expect(error?.message).to.include('Version is missing.')
+        })
     })
 })

--- a/test/cap-op-plugin.test.js
+++ b/test/cap-op-plugin.test.js
@@ -3,6 +3,10 @@ const { join } = require('node:path')
 const { execSync } = require('node:child_process')
 const { expect } = require('chai')
 const sinon = require('sinon')
+const https = require('https')
+const zlib = require('zlib')
+const { EventEmitter } = require('node:events')
+const { Readable } = require('node:stream')
 
 const TempUtil = require('./tempUtil')
 const tempUtil = new TempUtil(__filename, { local: true })
@@ -64,6 +68,8 @@ COMMANDS
 
     convert-to-configurable-template-chart [--with-runtime-yaml <runtime-yaml-path>]  Convert existing chart to configurable template chart
 
+    add-cap-operator-skill [--branch <branch-name> | --version <release-version>]   Add the CAP Operator agent skill to the .agents/skills/cap-operator folder
+
 EXAMPLES
 
     cap-op-plugin generate-runtime-values
@@ -71,6 +77,10 @@ EXAMPLES
 
     cap-op-plugin convert-to-configurable-template-chart
     cap-op-plugin convert-to-configurable-template-chart --with-runtime-yaml /path/to/runtime.yaml
+
+    cap-op-plugin add-cap-operator-skill
+    cap-op-plugin add-cap-operator-skill --branch main
+    cap-op-plugin add-cap-operator-skill --version v0.33.0
 `)
     })
 
@@ -274,5 +284,273 @@ EXAMPLES
         }
 
         expect(error?.message).to.equal('Only a-z, 0-9 and - are allowed')
+    })
+
+    //------------------------------------------------
+    // add-cap-operator-skill test cases
+    //------------------------------------------------
+
+    function makeTarGz(files) {
+        // files: [{ path, content }] — builds a minimal .tar.gz in memory
+        const blocks = []
+        for (const { path: filePath, content } of files) {
+            const contentBuf = Buffer.isBuffer(content) ? content : Buffer.from(content)
+            const header = Buffer.alloc(512)
+            header.write(filePath, 0, 100, 'utf8')
+            header.write('0000644\0', 100, 8, 'utf8')  // mode
+            const sizeOctal = contentBuf.length.toString(8).padStart(11, '0') + ' '
+            header.write(sizeOctal, 124, 12, 'utf8')
+            header.write('0', 156, 1, 'utf8')  // type: regular file
+            // checksum
+            header.fill(32, 148, 156)
+            let sum = 0
+            for (let i = 0; i < 512; i++) sum += header[i]
+            header.write(sum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'utf8')
+
+            blocks.push(header)
+            const padded = Buffer.alloc(Math.ceil(contentBuf.length / 512) * 512)
+            contentBuf.copy(padded)
+            blocks.push(padded)
+        }
+        blocks.push(Buffer.alloc(1024)) // EOF marker
+        return zlib.gzipSync(Buffer.concat(blocks))
+    }
+
+    function stubHttpsWithTarball(tag, tarGzBuf) {
+        sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
+            const req = new EventEmitter()
+            setImmediate(() => {
+                if (url.includes('releases/latest')) {
+                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                    callback(res)
+                    res.push(JSON.stringify({ tag_name: tag }))
+                    res.push(null)
+                } else {
+                    const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                    callback(res)
+                    res.push(tarGzBuf)
+                    res.push(null)
+                }
+            })
+            return req
+        })
+    }
+
+    function stubHttpsTarballOnly(tarGzBuf) {
+        sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
+            const req = new EventEmitter()
+            setImmediate(() => {
+                const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                callback(res)
+                res.push(tarGzBuf)
+                res.push(null)
+            })
+            return req
+        })
+    }
+
+    afterEach(() => {
+        if (cds.utils.exists(join(bookshop, '.agents')))
+            execSync('rm -rf .agents', { cwd: bookshop })
+    })
+
+    it('Add CAP Operator skill extracts .agents folder from tarball', async () => {
+        const tarGz = makeTarGz([
+            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
+            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/deploy.md', content: '# deploy' },
+            { path: 'cap-operator-v0.33.0/README.md', content: 'readme' }
+        ])
+        stubHttpsWithTarball('v0.33.0', tarGz)
+
+        cds.root = bookshop
+        try {
+            await capOperatorPlugin('add-cap-operator-skill')
+        } finally {
+            sinon.restore()
+        }
+
+        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.be.ok
+        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.be.ok
+        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL')
+        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/references/deploy.md'))).to.equal('# deploy')
+    })
+
+    it('Add CAP Operator skill overwrites existing files', async () => {
+        await cds.utils.write('old content').to(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))
+
+        const tarGz = makeTarGz([
+            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: 'new content' }
+        ])
+        stubHttpsWithTarball('v0.33.0', tarGz)
+
+        cds.root = bookshop
+        try {
+            await capOperatorPlugin('add-cap-operator-skill')
+        } finally {
+            sinon.restore()
+        }
+
+        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('new content')
+    })
+
+    it('Add CAP Operator skill prunes files removed upstream on re-run', async () => {
+        cds.root = bookshop
+
+        // First run: ships two reference files
+        const firstTar = makeTarGz([
+            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL' },
+            { path: 'cap-operator-v0.33.0/.agents/skills/cap-operator/references/old.md', content: '# old' }
+        ])
+        stubHttpsWithTarball('v0.33.0', firstTar)
+        try {
+            await capOperatorPlugin('add-cap-operator-skill')
+        } finally {
+            sinon.restore()
+        }
+        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.be.ok
+
+        // A user's own skill living alongside — must survive the re-run
+        await cds.utils.write('mine').to(join(bookshop, '.agents/skills/my-own/SKILL.md'))
+
+        // Second run: upstream dropped old.md
+        const secondTar = makeTarGz([
+            { path: 'cap-operator-v0.34.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v2' }
+        ])
+        stubHttpsWithTarball('v0.34.0', secondTar)
+        try {
+            await capOperatorPlugin('add-cap-operator-skill')
+        } finally {
+            sinon.restore()
+        }
+
+        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v2')
+        expect(cds.utils.exists(join(bookshop, '.agents/skills/cap-operator/references/old.md'))).to.not.be.ok
+        // unrelated user skill is untouched
+        expect(await cds.utils.read(join(bookshop, '.agents/skills/my-own/SKILL.md'))).to.equal('mine')
+    })
+
+    it('Add CAP Operator skill throws when release fetch fails', async () => {
+        sinon.stub(https, 'get').callsFake((_url, _opts, callback) => {
+            const req = new EventEmitter()
+            setImmediate(() => {
+                const res = Object.assign(new Readable({ read() {} }), { statusCode: 404, headers: {} })
+                callback(res)
+                res.push(null)
+            })
+            return req
+        })
+
+        cds.root = bookshop
+        let error
+        try {
+            await capOperatorPlugin('add-cap-operator-skill')
+        } catch (e) {
+            error = e
+        } finally {
+            sinon.restore()
+        }
+
+        expect(error?.message).to.include('HTTP 404')
+    })
+
+    it('Add CAP Operator skill throws when tarball has no .agents folder', async () => {
+        const tarGz = makeTarGz([
+            { path: 'cap-operator-v0.1.0/README.md', content: 'readme' }
+        ])
+        stubHttpsWithTarball('v0.1.0', tarGz)
+
+        cds.root = bookshop
+        let error
+        try {
+            await capOperatorPlugin('add-cap-operator-skill')
+        } catch (e) {
+            error = e
+        } finally {
+            sinon.restore()
+        }
+
+        expect(error?.message).to.include('No .agents folder found in cap-operator v0.1.0')
+    })
+
+    it('Add CAP Operator skill --version downloads specific release tarball', async () => {
+        const tarGz = makeTarGz([
+            { path: 'cap-operator-v0.30.0/.agents/skills/cap-operator/SKILL.md', content: '# SKILL v0.30.0' }
+        ])
+
+        let capturedUrl
+        sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
+            capturedUrl = url
+            const req = new EventEmitter()
+            setImmediate(() => {
+                const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                callback(res)
+                res.push(tarGz)
+                res.push(null)
+            })
+            return req
+        })
+
+        cds.root = bookshop
+        try {
+            await capOperatorPlugin('add-cap-operator-skill', '--version', 'v0.30.0')
+        } finally {
+            sinon.restore()
+        }
+
+        expect(capturedUrl).to.include('tags/v0.30.0')
+        expect(capturedUrl).to.not.include('releases/latest')
+        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL v0.30.0')
+    })
+
+    it('Add CAP Operator skill --branch downloads branch tarball without API call', async () => {
+        const tarGz = makeTarGz([
+            { path: 'cap-operator-main/.agents/skills/cap-operator/SKILL.md', content: '# SKILL main' }
+        ])
+
+        let capturedUrl
+        sinon.stub(https, 'get').callsFake((url, _opts, callback) => {
+            capturedUrl = url
+            const req = new EventEmitter()
+            setImmediate(() => {
+                const res = Object.assign(new Readable({ read() {} }), { statusCode: 200, headers: {} })
+                callback(res)
+                res.push(tarGz)
+                res.push(null)
+            })
+            return req
+        })
+
+        cds.root = bookshop
+        try {
+            await capOperatorPlugin('add-cap-operator-skill', '--branch', 'main')
+        } finally {
+            sinon.restore()
+        }
+
+        expect(capturedUrl).to.include('heads/main')
+        expect(capturedUrl).to.not.include('releases/latest')
+        expect(await cds.utils.read(join(bookshop, '.agents/skills/cap-operator/SKILL.md'))).to.equal('# SKILL main')
+    })
+
+    it('Add CAP Operator skill --branch missing value shows usage error', async () => {
+        cds.root = bookshop
+        let error
+        try {
+            await capOperatorPlugin('add-cap-operator-skill', '--branch', undefined)
+        } catch (e) {
+            error = e
+        }
+        expect(error?.message).to.include('Branch name is missing.')
+    })
+
+    it('Add CAP Operator skill --version missing value shows usage error', async () => {
+        cds.root = bookshop
+        let error
+        try {
+            await capOperatorPlugin('add-cap-operator-skill', '--version', undefined)
+        } catch (e) {
+            error = e
+        }
+        expect(error?.message).to.include('Version is missing.')
     })
 })


### PR DESCRIPTION
# ✨ Add `add-cap-operator-skill` Command for AI Coding Assistant Integration

### New Feature

Introduces a new `add-cap-operator-skill` command to the `cap-op-plugin` CLI. This command downloads the CAP Operator agent skill from a published tarball (`https://sap.github.io/cap-operator/agentskills.tar.gz`) and installs it into the project's `.agents/skills/cap-operator/` folder, enabling AI coding assistants (e.g., Claude Code) to understand and manage CAP Operator Kubernetes resources.

Key behaviors:
- **Re-run safe**: The existing `cap-operator` skill directory is wiped before extraction, pruning stale files, while other skills under `.agents/` remain untouched.
- **Redirect support**: The HTTP download helper follows up to 10 redirects.

### Changes

* `bin/cap-op-plugin.js`: Registered `add-cap-operator-skill` in the `SUPPORTED` command map; implemented `httpGet()` helper with redirect support; implemented `addCapOperatorSkill()` function; added the new command to CLI usage/help text; renamed internal parameter `yamlPath` → `optionValue` for consistency.
* `README.md`: Updated minimum `@sap/cds-dk` version requirement from `>=8.2.1` to `>=9`; added a new documentation section for `add-cap-operator-skill` including usage examples and Claude Code integration instructions.
* `test/cap-op-plugin.test.js`: Added a test suite covering live tarball extraction, file overwrite on re-run, stale file pruning, preservation of unrelated skills, and rejection of unknown options; updated the usage help text snapshot.
* `CHANGELOG.md`: Added entry for version `0.19.0` documenting the new command.
* `package.json` / `package-lock.json`: Bumped version from `0.18.0` to `0.19.0`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.2`

- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `df8915d0-899d-11f1-888a-0bdf84f9d67e`
- Event Trigger: `pull_request.edited`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
