### PR TITLE
[Misc] Added Workzone service to helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/). The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.20.0 - 12-August-2026
+## Version 0.20.0 - 17-August-2026
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/). The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Version 0.20.0 - 12-August-2026
+
+### Added
+
+- Added support for SAP Build Work Zone, Standard Edition (`workzone-standard`). Generates a `build-workzone-standard` service instance (`local-entry-point` plan) and binding, with workloads updated as required.
+
 ## Version 0.19.0 - 31-July-2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/). The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## Version 0.20.0 - 17-August-2026
+## Version 0.20.0 - 18-August-2026
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
-- Added support for SAP Build Work Zone, Standard Edition (`workzone-standard`). Generates a `build-workzone-standard` service instance (`local-entry-point` plan) and binding, with workloads updated as required.
+- Added support for SAP Build Work Zone, Standard Edition, generating a `build-workzone-standard` service instance with the `local-entry-point` plan and binding, along with the required workload updates.
 
 ## Version 0.19.0 - 31-July-2026
 

--- a/files/approuter.yaml.hbs
+++ b/files/approuter.yaml.hbs
@@ -22,9 +22,17 @@ workloads:
         {{#hasHTML5Repo}}
         - {{appName}}-html5-repo-runtime-bind
         {{/hasHTML5Repo}}
+        {{#hasWorkzoneStandard}}
+        - {{appName}}-workzone-bind
+        {{/hasWorkzoneStandard}}
         deploymentDefinition:
             type: Router
             image:
             ports:
             - name: router-port
               port: 5000
+            {{#hasWorkzoneStandard}}
+            env:
+            - name: OWN_SAP_CLOUD_SERVICE
+              value: '["{{strippedAppName}}.service"]'
+            {{/hasWorkzoneStandard}}

--- a/files/workloads.yaml.hbs
+++ b/files/workloads.yaml.hbs
@@ -54,9 +54,17 @@ workloads:
         {{#hasHtml5Repo}}
         - {{appName}}-html5-repo-host-bind
         {{/hasHtml5Repo}}
+        {{#hasWorkzoneStandard}}
+        - {{appName}}-workzone-bind
+        {{/hasWorkzoneStandard}}
         jobDefinition:
             type: Content
             image:
+            {{#hasWorkzoneStandard}}
+            env:
+            - name: ASYNC_UPLOAD
+              value: "true"
+            {{/hasWorkzoneStandard}}
 
     {{#isApp}}
     tenantJob:

--- a/files/workloads.yaml.hbs
+++ b/files/workloads.yaml.hbs
@@ -60,11 +60,6 @@ workloads:
         jobDefinition:
             type: Content
             image:
-            {{#hasWorkzoneStandard}}
-            env:
-            - name: ASYNC_UPLOAD
-              value: "true"
-            {{/hasWorkzoneStandard}}
 
     {{#isApp}}
     tenantJob:

--- a/files/workzone.yaml.hbs
+++ b/files/workzone.yaml.hbs
@@ -1,0 +1,15 @@
+serviceInstances:
+    workzone:
+        name: {{appName}}-wz-service
+        serviceOfferingName: build-workzone-standard
+        servicePlanName: local-entry-point
+        parameters:
+            providerId:
+            exposureId:
+serviceBindings:
+    workzone:
+        name: {{appName}}-workzone-bind
+        serviceInstanceName: {{appName}}-wz-service
+        secretName: {{appName}}-workzone-bind-secret
+        secretKey: credentials
+        parameters: {}

--- a/files/workzone.yaml.hbs
+++ b/files/workzone.yaml.hbs
@@ -4,7 +4,7 @@ serviceInstances:
         serviceOfferingName: build-workzone-standard
         servicePlanName: local-entry-point
         parameters:
-            providerId: {{strippedAppName}}
+            providerId: {{workzoneProviderId}}
             exposureId: "{{strippedAppName}}.service"
 serviceBindings:
     workzone:

--- a/files/workzone.yaml.hbs
+++ b/files/workzone.yaml.hbs
@@ -4,8 +4,8 @@ serviceInstances:
         serviceOfferingName: build-workzone-standard
         servicePlanName: local-entry-point
         parameters:
-            providerId:
-            exposureId:
+            providerId: {{strippedAppName}}
+            exposureId: "{{strippedAppName}}.service"
 serviceBindings:
     workzone:
         name: {{appName}}-workzone-bind

--- a/files/workzone.yaml.hbs
+++ b/files/workzone.yaml.hbs
@@ -1,6 +1,6 @@
 serviceInstances:
     workzone:
-        name: {{appName}}-wz-service
+        name: {{appName}}-workzone-service
         serviceOfferingName: build-workzone-standard
         servicePlanName: local-entry-point
         parameters:
@@ -9,7 +9,7 @@ serviceInstances:
 serviceBindings:
     workzone:
         name: {{appName}}-workzone-bind
-        serviceInstanceName: {{appName}}-wz-service
+        serviceInstanceName: {{appName}}-workzone-service
         secretName: {{appName}}-workzone-bind-secret
         secretKey: credentials
         parameters: {}

--- a/lib/add.js
+++ b/lib/add.js
@@ -125,8 +125,6 @@ module.exports = class CapOperatorAddPlugin extends cds.add.Plugin {
             hasMultitenancy, hasIas, hasWorkzoneStandard
         } = project
 
-        if (hasWorkzoneStandard) project.workzoneProviderId = project.strippedAppName.slice(0, 20)
-
         const valuesPath = join(cds.root, 'chart/values.yaml')
         const valuesYaml = yaml.parse(await read(valuesPath))
 

--- a/lib/add.js
+++ b/lib/add.js
@@ -122,7 +122,7 @@ module.exports = class CapOperatorAddPlugin extends cds.add.Plugin {
         const project = this.readProject(isServiceOnly)
         const {
             hasDestination, hasHtml5Repo, hasXsuaa, hasApprouter,
-            hasMultitenancy, hasIas
+            hasMultitenancy, hasIas, hasWorkzoneStandard
         } = project
 
         const valuesPath = join(cds.root, 'chart/values.yaml')
@@ -137,6 +137,7 @@ module.exports = class CapOperatorAddPlugin extends cds.add.Plugin {
 
         await addIf(hasDestination, '../files/destination.yaml.hbs')
         await addIf(hasHtml5Repo, '../files/html5Repo.yaml.hbs')
+        await addIf(hasWorkzoneStandard, '../files/workzone.yaml.hbs')
         await addIf(hasIas, '../files/ias.yaml.hbs')
         await addIf(!hasIas && hasXsuaa, '../files/xsuaa.yaml.hbs')
 

--- a/lib/add.js
+++ b/lib/add.js
@@ -125,6 +125,8 @@ module.exports = class CapOperatorAddPlugin extends cds.add.Plugin {
             hasMultitenancy, hasIas, hasWorkzoneStandard
         } = project
 
+        if (hasWorkzoneStandard) project.workzoneProviderId = project.strippedAppName.slice(0, 20)
+
         const valuesPath = join(cds.root, 'chart/values.yaml')
         const valuesYaml = yaml.parse(await read(valuesPath))
 
@@ -137,9 +139,13 @@ module.exports = class CapOperatorAddPlugin extends cds.add.Plugin {
 
         await addIf(hasDestination, '../files/destination.yaml.hbs')
         await addIf(hasHtml5Repo, '../files/html5Repo.yaml.hbs')
-        await addIf(hasWorkzoneStandard, '../files/workzone.yaml.hbs')
         await addIf(hasIas, '../files/ias.yaml.hbs')
         await addIf(!hasIas && hasXsuaa, '../files/xsuaa.yaml.hbs')
+
+        if (hasWorkzoneStandard) {
+            project.workzoneProviderId = project.strippedAppName.slice(0, 20)
+            await addIf(true, '../files/workzone.yaml.hbs')
+        }
 
         if (hasMultitenancy) {
             await addIf(hasIas, '../files/subscription-manager.yaml.hbs')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cap-operator-plugin",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cap-operator-plugin",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Add/Build Plugin for CAP Operator",
   "homepage": "https://github.com/cap-js/cap-operator-plugin/blob/main/README.md",
   "repository": {

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -2,6 +2,7 @@ const { join } = require('node:path')
 const { execSync } = require('node:child_process')
 const { expect } = require('chai')
 const fs = require('node:fs')
+const yaml = require('yaml')
 
 const TempUtil = require('./tempUtil')
 const tempUtil = new TempUtil(__filename, { local: true })
@@ -320,5 +321,38 @@ describe('cds add cap-operator', () => {
         const log = execSync(`cds add cap-operator`, { cwd: bookshop }).toString()
 
         expect(log).to.not.include("'btp.provider'")
+    })
+
+    it('Add cap-operator chart with workzone-standard', async () => {
+        execSync(`cds add workzone-standard`, { cwd: bookshop })
+        execSync(`cds add cap-operator`, { cwd: bookshop })
+
+        const parsed = yaml.parse(fs.readFileSync(join(bookshop, 'chart/values.yaml'), 'utf8'))
+
+        // service instance
+        const wzInstance = parsed.serviceInstances.workzone
+        expect(wzInstance.serviceOfferingName).to.equal('build-workzone-standard')
+        expect(wzInstance.servicePlanName).to.equal('local-entry-point')
+        expect(wzInstance.parameters.providerId).to.equal('bookshop')
+        expect(wzInstance.parameters.exposureId).to.equal('bookshop.service')
+
+        // service binding
+        const wzBinding = parsed.serviceBindings.workzone
+        expect(wzBinding.name).to.equal('bookshop-workzone-bind')
+        expect(wzBinding.serviceInstanceName).to.equal('bookshop-workzone-service')
+
+        // appRouter: workzone binding in consumedBTPServices + OWN_SAP_CLOUD_SERVICE env var
+        const appRouter = parsed.workloads.appRouter
+        expect(appRouter.consumedBTPServices).to.include('bookshop-workzone-bind')
+        const ownSapCloudService = appRouter.deploymentDefinition.env?.find(e => e.name === 'OWN_SAP_CLOUD_SERVICE')
+        expect(ownSapCloudService).to.exist
+        expect(ownSapCloudService.value).to.include('bookshop.service')
+
+        // contentDeploy: workzone binding in consumedBTPServices + ASYNC_UPLOAD env var
+        const contentDeploy = parsed.workloads.contentDeploy
+        expect(contentDeploy.consumedBTPServices).to.include('bookshop-workzone-bind')
+        const asyncUpload = contentDeploy.jobDefinition.env?.find(e => e.name === 'ASYNC_UPLOAD')
+        expect(asyncUpload).to.exist
+        expect(asyncUpload.value).to.equal('true')
     })
 })

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -349,11 +349,8 @@ describe('cds add cap-operator', () => {
         expect(ownSapCloudService).to.exist
         expect(ownSapCloudService.value).to.include('bookshop.service')
 
-        // contentDeploy: workzone binding in consumedBTPServices + ASYNC_UPLOAD env var
+        // contentDeploy: workzone binding in consumedBTPServices
         const contentDeploy = parsed.workloads.contentDeploy
         expect(contentDeploy.consumedBTPServices).to.include('bookshop-workzone-bind')
-        const asyncUpload = contentDeploy.jobDefinition.env?.find(e => e.name === 'ASYNC_UPLOAD')
-        expect(asyncUpload).to.exist
-        expect(asyncUpload.value).to.equal('true')
     })
 })

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -334,6 +334,7 @@ describe('cds add cap-operator', () => {
         expect(wzInstance.serviceOfferingName).to.equal('build-workzone-standard')
         expect(wzInstance.servicePlanName).to.equal('local-entry-point')
         expect(wzInstance.parameters.providerId).to.equal('bookshop')
+        expect(wzInstance.parameters.providerId.length).to.be.at.most(20)
         expect(wzInstance.parameters.exposureId).to.equal('bookshop.service')
 
         // service binding


### PR DESCRIPTION
# Add SAP Build Work Zone Standard Edition(local-entry-point plan) Support to Helm Chart

### New Feature

✨ Adds support for **SAP Build Work Zone, Standard Edition** (`build-workzone-standard`) 'local-entry-point' plan to the CAP Operator Helm chart plugin (v0.20.0). When enabled, the plugin generates a `build-workzone-standard` service instance (`local-entry-point` plan) and its binding, and updates the relevant workloads accordingly.

### Changes

* `files/workzone.yaml.hbs`: New Mustache template defining the `build-workzone-standard` service instance and binding, with `providerId` (truncated to 20 chars) and `exposureId` parameters derived from the app name.
* `files/approuter.yaml.hbs`: Added conditional inclusion of the workzone binding in `consumedBTPServices` and injects the `OWN_SAP_CLOUD_SERVICE` environment variable when Workzone Standard is enabled.
* `files/workloads.yaml.hbs`: Added conditional inclusion of the workzone binding in the `contentDeploy` job's `consumedBTPServices` when Workzone Standard is enabled.
* `lib/add.js`: Extracted `hasWorkzoneStandard` from the project descriptor; computes `workzoneProviderId` (app name, max 20 chars) and conditionally merges `workzone.yaml.hbs` into `values.yaml` during the `combine` step.
* `test/add.test.js`: Added integration test verifying correct generation of the Workzone service instance, binding, approuter `OWN_SAP_CLOUD_SERVICE` env var, and content deploy binding when `workzone-standard` is added.
* `CHANGELOG.md`: Added entry for version `0.20.0` documenting the new Workzone Standard support.
* `package.json` / `package-lock.json`: Bumped version from `0.19.0` to `0.20.0`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `10bb64f0-96f0-11f1-9b9b-f6f21fe50925`
</details>
