### PR TITLE
[Misc] Plugin: Year updated

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,5 +7,5 @@ SPDX-PackageComment = "The code in this project may include calls to APIs (\"API
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors"
+SPDX-FileCopyrightText = "2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/bin/cap-op-plugin.js
+++ b/bin/cap-op-plugin.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 /*
-SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/hack/schema-generation.go
+++ b/hack/schema-generation.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -21,11 +21,11 @@ type Domains struct {
 }
 
 type app struct {
-	Domains                    Domains           `json:"domains"`
-	IstioIngressGatewayLabels  map[string]string `json:"istioIngressGatewayLabels"`
-	Version                    string            `json:"version,omitempty"`
-	EnableCleanupMonitoring    bool              `json:"enableCleanupMonitoring,omitempty"`
-	RolloutOnCredentialUpdate  bool              `json:"rolloutOnCredentialUpdate,omitempty"`
+	Domains                   Domains           `json:"domains"`
+	IstioIngressGatewayLabels map[string]string `json:"istioIngressGatewayLabels"`
+	Version                   string            `json:"version,omitempty"`
+	EnableCleanupMonitoring   bool              `json:"enableCleanupMonitoring,omitempty"`
+	RolloutOnCredentialUpdate bool              `json:"rolloutOnCredentialUpdate,omitempty"`
 }
 
 type SubscriptionDependencyMode string

--- a/lib/add.js
+++ b/lib/add.js
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/lib/mta-transformer.js
+++ b/lib/mta-transformer.js
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator-plugin contributors
 SPDX-License-Identifier: Apache-2.0
 */
 


### PR DESCRIPTION
# Update Copyright Year to 2026

### Chore

🗓️ Updated the copyright year from `2025` to `2026` in SPDX license headers across all source files, along with a minor whitespace alignment fix in `hack/schema-generation.go`.

### Changes

* `REUSE.toml`: Updated `SPDX-FileCopyrightText` year from 2025 to 2026.
* `bin/cap-op-plugin.js`: Updated copyright year in file header.
* `cds-plugin.js`: Updated copyright year in file header.
* `hack/schema-generation.go`: Updated copyright year and fixed struct field alignment formatting.
* `lib/add.js`: Updated copyright year in file header.
* `lib/build.js`: Updated copyright year in file header.
* `lib/mta-transformer.js`: Updated copyright year in file header.
* `lib/util.js`: Updated copyright year in file header.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.30`

- Correlation ID: `9face710-9b00-11f1-8e77-ef87a55148f7`
- Event Trigger: `issue_comment.edited`
</details>
